### PR TITLE
Add basic authentication functionality to codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ So what is the script doing:
 - Running as a service
 - Connecting to DBus of the Venus OS `com.victronenergy.pvinverter.http_{DeviceInstanceID_from_config}`
 - After successful DBus connection, OpenDTU (resp. Ahoy) is accessed via REST-API - simply the `/status` (resp. `api/live`) is called which returns a JSON with all details.
-  A sample JSON file from OpenDTU can be found [here](docs/OpenDTU.json). A sample JSON file from OpenDTU can be found [here](docs/ahoy.json)
+  - A sample JSON file from OpenDTU can be found [here](docs/OpenDTU.json). 
+  - A sample JSON file from Ahoy can be found [here](docs/ahoy_0.6.9_live.json)
 - Serial/devicename is taken from the response as device serial
 - Paths are added to the DBus with default value 0 - including some settings like name etc.
 - After that, a "loop" is started which pulls OpenDTU/AhoyDTU data every 5s (configurable) from the REST-API and updates the values in the DBus, for ESP 8266 based ahoy systems we even pull data only every 10seconds.
@@ -175,5 +176,7 @@ This module/repository has been posted on the following threads:
 - https://community.victronenergy.com/questions/169076/opendtu-as-pv-inverter-in-venusos.html
 
 ## Video on how to install and use:
+*(Don't be confused that the config they used is not the actual one.)*
+
 - https://youtu.be/PpjCz33pGkk Meine Energiewende
 - https://youtu.be/UNuIOa72eP4 Schatten PV

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -370,6 +370,9 @@ class DbusService:
             logging.debug(f"calling {url_anonymize(url)} with timeout={self.httptimeout}")
             if not self.digestauth:
                 json_str = requests.get(url=url, timeout=float(self.httptimeout))
+            elif self.username and self.password:
+                logging.debug(f"using basic auth for {url_anonymize(url)}") 
+                json_str = requests.get(url=url, auth=(self.username, self.password), timeout=float(self.httptimeout))
             else:
                 json_str = requests.get(url=url, auth=HTTPDigestAuth(self.username, self.password), timeout=float(self.httptimeout))
             json_str.raise_for_status() # raise exception on bad status code

--- a/docs/ahoy_0.6.9_live.json
+++ b/docs/ahoy_0.6.9_live.json
@@ -1,0 +1,47 @@
+{
+  "generic": {
+    "wifi_rssi": -65,
+    "ts_uptime": 3895,
+    "menu_prot": false,
+    "menu_mask": 61,
+    "menu_protEn": false,
+    "esp_type": "ESP8266"
+  },
+  "refresh": 10,
+  "ch0_fld_units": [
+    "V",
+    "A",
+    "W",
+    "Hz",
+    "",
+    "°C",
+    "kWh",
+    "Wh",
+    "W",
+    "%",
+    "var"
+  ],
+  "ch0_fld_names": [
+    "U_AC",
+    "I_AC",
+    "P_AC",
+    "F_AC",
+    "PF_AC",
+    "Temp",
+    "YieldTotal",
+    "YieldDay",
+    "P_DC",
+    "Efficiency",
+    "Q_AC"
+  ],
+  "fld_units": ["V", "A", "W", "Wh", "kWh", "%"],
+  "fld_names": [
+    "U_DC",
+    "I_DC",
+    "P_DC",
+    "YieldDay",
+    "YieldTotal",
+    "Irradiation"
+  ],
+  "iv": [true, false, false, false, false, false, false, false, false, false]
+}


### PR DESCRIPTION
I have made some changes to the Python codebase to add basic authentication functionality to the requests being made. I needed that to get access to a rest interface that uses basic auth. I believed that it was already built in and wondered why it didn't work. Therefore the change which I made:

```python
elif self.username and self.password:
    logging.debug(f"using basic auth for {url_anonymize(url)}") 
    json_str = requests.get(url=url, auth=(self.username, self.password), timeout=float(self.httptimeout))
``` 
With this code, if the username and password fields are set, the code will use basic authentication to send the request to the specified URL. The logging module is also used to log a debug message when this happens.

Furthermore, I update the readme to correct a duplicate and relocate the links.

Please review this pull request and merge it into the codebase if it meets the project's standards.