### PR TITLE
Fix self-created and another bug related to auth.

### DIFF
--- a/dbus_service.py
+++ b/dbus_service.py
@@ -291,8 +291,7 @@ class DbusService:
 
     def get_opendtu_base_url(self):
         '''Get API base URL for all OpenDTU calls'''
-        url = f"http://{self.username}:{self.password}@{self.host}/api"
-        return url.replace(":@", "")
+        return f"http://{self.host}/api"
 
     def get_ahoy_base_url(self):
         '''Get API base URL for all Ahoy calls'''
@@ -362,11 +361,12 @@ class DbusService:
     def fetch_url(self, url, try_number = 1):
         '''Fetch JSON data from url. Throw an exception on any error. Only return on success.'''
         try:
-            logging.debug(f"calling {url_anonymize(url)} with timeout={self.httptimeout}")
+            logging.debug(f"calling {url} with timeout={self.httptimeout}")
             if self.digestauth:
+                logging.debug("using Digest access authentication...") 
                 json_str = requests.get(url=url, auth=HTTPDigestAuth(self.username, self.password), timeout=float(self.httptimeout))
             elif self.username and self.password:
-                logging.debug(f"using basic auth for {url_anonymize(url)}") 
+                logging.debug("basic access authentication...") 
                 json_str = requests.get(url=url, auth=(self.username, self.password), timeout=float(self.httptimeout))
             else:
                 json_str = requests.get(url=url, timeout=float(self.httptimeout))
@@ -386,7 +386,7 @@ class DbusService:
             # check for Json
             if not json:
                 # will be logged when catched
-                raise ValueError(f"Converting response from {url_anonymize(url)} to JSON failed:\nstatus={json_str.status_code},\nresponse={json_str.text}")
+                raise ValueError(f"Converting response from {url} to JSON failed:\nstatus={json_str.status_code},\nresponse={json_str.text}")
             return json
         except:
             if (try_number < 3): # retry same call up to 3 times
@@ -482,10 +482,10 @@ class DbusService:
             successful = True
         except requests.exceptions.RequestException as exception:
             if self.last_update_successful:
-                logging.warning(f"HTTP Error at _update for inverter {self.pvinverternumber} ({self._get_name()}): {url_anonymize(str(exception))}")
+                logging.warning(f"HTTP Error at _update for inverter {self.pvinverternumber} ({self._get_name()}): {str(exception)}")
         except ValueError as error:
             if self.last_update_successful:
-                logging.warning(f"Error at _update for inverter {self.pvinverternumber} ({self._get_name()}): {url_anonymize(str(error))}")
+                logging.warning(f"Error at _update for inverter {self.pvinverternumber} ({self._get_name()}): {str(error)}")
         except Exception as error:
             if self.last_update_successful:
                 logging.warning(f"Error at _update for inverter {self.pvinverternumber} ({self._get_name()})", exc_info=error)

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -366,7 +366,7 @@ class DbusService:
                 logging.debug("using Digest access authentication...") 
                 json_str = requests.get(url=url, auth=HTTPDigestAuth(self.username, self.password), timeout=float(self.httptimeout))
             elif self.username and self.password:
-                logging.debug("basic access authentication...") 
+                logging.debug("using Basic access authentication...") 
                 json_str = requests.get(url=url, auth=(self.username, self.password), timeout=float(self.httptimeout))
             else:
                 json_str = requests.get(url=url, timeout=float(self.httptimeout))

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -129,15 +129,6 @@ class DbusService:
         gobject.timeout_add(self._get_sign_of_life_interval() * 60 * 1000, self._sign_of_life)
 
     ## read config file
-    def stringToBool(self, s):
-        if s == "False":
-            bool_flag = False
-        elif s == "True":
-            bool_flag = True
-        else:
-            raise ValueError(f"value '{s}' cannot be converted to boolean")
-        return bool_flag
-
     def _read_config_dtu(self, actual_inverter):
         config = self._get_config()
         self.pvinverternumber = actual_inverter
@@ -152,7 +143,7 @@ class DbusService:
         self.host = get_config_value(config, "Host", "INVERTER", self.pvinverternumber )
         self.username = get_config_value(config, "Username", "INVERTER", self.pvinverternumber )
         self.password = get_config_value(config, "Password", "INVERTER", self.pvinverternumber )
-        self.digestauth = self.stringToBool(get_config_value(config, "DigestAuth", "INVERTER", self.pvinverternumber, "False" ))
+        self.digestauth = is_true(get_config_value(config, "DigestAuth", "INVERTER", self.pvinverternumber, False ))
 
         try:
             self.max_age_ts = int(config["DEFAULT"]["MagAgeTsLastSuccess"])
@@ -190,7 +181,7 @@ class DbusService:
         self.signofliveinterval = config["DEFAULT"]["SignOfLifeLog"]
         self.useyieldday = int(config["DEFAULT"]["useYieldDay"])
         self.pvinverterphase = str(config[f"TEMPLATE{template_number}"]["Phase"])
-        self.digestauth = self.stringToBool(get_config_value(config, "DigestAuth", "TEMPLATE", template_number, "False"))
+        self.digestauth =  is_true(get_config_value(config, "DigestAuth", "TEMPLATE", template_number, False))
 
         try:
             self.max_age_ts = int(config["DEFAULT"]["MagAgeTsLastSuccess"])

--- a/helpers.py
+++ b/helpers.py
@@ -39,10 +39,6 @@ def get_nested(meter_data, path):
                 value = 0
     return value
 
-def url_anonymize(url):
-    '''remove username & password from URL for debug logging'''
-    return re.sub(r'//.*:.*\@',r'//****:****@',url)
-
 def get_ahoy_field_by_name(meter_data, actual_inverter, fieldname):
     '''get the value by name instead of list index'''
     # fetch value from record call:

--- a/helpers.py
+++ b/helpers.py
@@ -62,7 +62,7 @@ def get_ahoy_field_by_name(meter_data, actual_inverter, fieldname):
 
 def is_true(val):
     '''helper function to test for different true values'''
-    return val in (1, '1', True)
+    return val in (1, '1', True, "True", "true")
 
 def timeit(func):
     @functools.wraps(func)


### PR DESCRIPTION
I apologize for creating another pull request, but my previous code had not should work like it is. 

Explanation: 

pay attention to **"DigistAuth"** in my configuration file:

``` config
[TEMPLATE0]
Username = ****
Password = *****
Host=192.168.1.11:1880
DigestAuth = False
CUST_SN = 12345678
CUST_API_PATH= getSolarPowermeterState
CUST_POLLING = 10000
CUST_Total= Energy
CUST_Total_Mult = 1
CUST_Power= Power
CUST_Power_Mult = 1
CUST_Voltage= voltage
CUST_Current= current
Phase=L1
DeviceInstance=46
AcPosition=0
Name= FritzDect200
Servicename=com.victronenergy.pvinverter
```

My code was written with the intention to do a basic authentication if `self.digestauth` is false and a `username` and `password` are provided:

``` Python
if not self.digestauth:
  json_str = requests.get(url=url, timeout=float(self.httptimeout))
elif self.username and self.password:
  logging.debug(f"using basic auth for {url_anonymize(url)}"
else:
  json_str = requests.get(url=url, auth=(self.username, self.password), timeout=float(self.httptimeout))
``` 

This is falsely working right now because `digestauth` is true even though it should be false.


```log
2023-04-23 20:58:06,175 root DEBUG calling http://192.168.1.11:1880/getSolarPowermeterState with timeout=2.5
2023-04-23 20:58:06,176 root DEBUG value of digistauth is: True ENDE
2023-04-23 20:58:06,178 root DEBUG using basic auth for http://192.168.1.11:1880/getSolarPowermeterState
2023-04-23 20:58:06,190 urllib3.connectionpool DEBUG Starting new HTTP connection (1): 192.168.1.11:1880
2023-04-23 20:58:07,163 urllib3.connectionpool DEBUG http://192.168.1.11:1880 "GET /getSolarPowermeterState HTTP/1.1" 200 26
2023-04-23 20:58:07,171 root DEBUG function fetch_url finished in 996 ms
2023-04-23 20:58:07,176 root DEBUG Inverter #0 Power (/Ac/Power): 0.0
2023-04-23 20:58:07,184 root DEBUG Inverter #0 Energy (/Ac/Energy/Forward): 0.635
2023-04-23 20:58:07,187 root DEBUG ---
2023-04-23 20:58:07,194 root WARNING Recovered inverter 0 (FritzDect200): Successfully fetched data now: Is up-to-date
```

The solution is twofold:

1. Change the order of the authentication checks:

``` Python
if self.digestauth:
  json_str = requests.get(url=url, auth=HTTPDigestAuth(self.username, self.password), timeout=float(self.httptimeout))
elif self.username and self.password:
  logging.debug(f"using basic auth for {url_anonymize(url)}") 
  json_str = requests.get(url=url, auth=(self.username, self.password), timeout=float(self.httptimeout))
else:
  json_str = requests.get(url=url, timeout=float(self.httptimeout))
```

2. fix the getter of `self.digestauth` 

The current Implementation dos something like this:

```log
2023-04-23 21:32:34,474 root DEBUG GET NOW DigistAUTH! my template number is: 0
2023-04-23 21:32:34,476 root DEBUG config entry 'DigestAuth' found in TEMPLATE0 section
2023-04-23 21:32:34,478 root DEBUG config entry 'DigestAuth' value: False
2023-04-23 21:32:34,480 root DEBUG RESULT OF DigistAUTH! is: True
```

Which is not correct because 'DigestAuth' is False isn't it? 
The problem is that "print(bool("False"))" returns True. 

you won't see this problem at first because the function get_config_value gives you a default value which is False on
DigistAuth (for the Inverter section).

to solve that we will simply add a new function:

``` Python
def stringToBool(self, s):
  if s == "False":
    bool_flag = False
  elif s == "True":
    bool_flag = True
  else:
    raise ValueError(f"value '{s}' cannot be converted to boolean")
  return bool_flag
```

and change the default values a little bit like this:

``` python
self.digestauth = self.stringToBool(get_config_value(config, "DigestAuth", "INVERTER", self.pvinverternumber, "False" ))
```

now we get a boolean value if the user sets a True or a False value.


Also, the original Implementation works again but i suggest removing that part because it's not a good idea to send a username and password in the URL like this:

```log
2023-04-23 22:05:39,222 root DEBUG is_data_up2date: inverter #0: age_seconds=12904, max_age_ts=600
2023-04-23 22:05:39,322 root DEBUG calling http://****:****@192.168.1.11:1880/getSolarPowermeterState with timeout=2.5
2023-04-23 22:05:39,324 root DEBUG using basic auth for http://****:****@192.168.1.11:1880/getSolarPowermeterState
2023-04-23 22:05:39,337 urllib3.connectionpool DEBUG Starting new HTTP connection (1): 192.168.1.11:1880
2023-04-23 22:05:40,317 urllib3.connectionpool DEBUG http://192.168.1.11:1880 "GET /getSolarPowermeterState HTTP/1.1" 200 26
2023-04-23 22:05:40,325 root DEBUG function fetch_url finished in 1002 ms
2023-04-23 22:05:40,327 root DEBUG Inverter #0 Power (/Ac/Power): 0.0
2023-04-23 22:05:40,328 root DEBUG Inverter #0 Energy (/Ac/Energy/Forward): 0.635
2023-04-23 22:05:40,330 root DEBUG ---
```

I know that Basic Auth is unsafe especially over HTTP instead of HTTPS. Anyway, sending it via header is better here.
Therefor I removed that part.(you should change it also for "def get_opendtu_base_url(self):" 
I don't use opendtu and because of this, I left it unchanged.

Sorry again for sending a bugged code at first.