### PR TITLE
Adds HMT Power to first level

### DIFF
--- a/dbus_service.py
+++ b/dbus_service.py
@@ -662,12 +662,14 @@ class DbusService:
                 self._dbusservice["/Ac/L3/Voltage"] = singlePhaseVoltage 
                 self._dbusservice["/Ac/L3/Current"] = realCurrent
                 self._dbusservice["/Ac/L3/Power"] = powerthird
+                self._dbusservice["/Ac/Power"] = power
 
                 if power > 0:
                     self._dbusservice["/Ac/L1/Energy/Forward"] = pvyield / 3
                     self._dbusservice["/Ac/L2/Energy/Forward"] = pvyield / 3
                     self._dbusservice["/Ac/L3/Energy/Forward"] = pvyield / 3
                     self._dbusservice["/Ac/Energy/Forward"] = pvyield
+                    
             else:
                 pre = "/Ac/" + self.pvinverterphase
                 self._dbusservice[pre + "/Voltage"] = voltage


### PR DESCRIPTION
## Issue:
Using a HMT-2250 you do not see the total power in the first level, in the overview of all devices. First when you move into the device you see the power of each phase. 

## Fix
This PR fixes the issue. I tested it with my system and checked if the power of each phase is summed up with the total power. Which is not the case.