### PR TITLE
Specify number of inverters in config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Within the project there is a file `/data/dbus-opendtu/config.ini`. Most importa
 | Username | use if authentication required, leave empty if no authentication needed |
 | Password | use if authentication required, leave empty if no authentication needed |
 
-*1 Please assure that the order is correct in the DTU, we can only extract the first one in a row.
+*1: Please assure that the order is correct in the DTU, we can only extract the first one in a row.
 
 #### Inverter options
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Within the project there is a file `/data/dbus-opendtu/config.ini`. Most importa
 |-------------------- | ------------- |
 | SignOfLifeLog  | Time in minutes how often a status is added to the log-file `current.log` with log-level INFO |
 | NumberOfTemplates | Number ob Template Inverter to query |
-| DTU |  Which DTU to be used ahoy, opendtu or template REST devices Valid options: opendtu, ahoy, template |
+| DTU | Which DTU to be used ahoy, opendtu or template REST devices Valid options: opendtu, ahoy, template |
+| QueryOnlyFirstOfDTUInverter | Amount of Inverters you to query. Set a value larger than "0" when not all inverters should be considered. Please assure that the order is correct in the DTU, we can only extract the first one in a row. |
 | useYieldDay | send YieldDay instead of YieldTotal. Set this to 1 to prevent VRM from adding the total value to the history on one day. E.g. if you don't start using the inverter at 0. |
 | ESP8266PollingIntervall |  For ESP8266 reduce polling intervall to reduce load, default 10000ms|
 | Logging | Valid options for log level: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET, to keep logfile small use ERROR or CRITICAL |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Within the project there is a file `/data/dbus-opendtu/config.ini`. Most importa
 | SignOfLifeLog  | Time in minutes how often a status is added to the log-file `current.log` with log-level INFO |
 | NumberOfTemplates | Number ob Template Inverter to query |
 | DTU | Which DTU to be used ahoy, opendtu or template REST devices Valid options: opendtu, ahoy, template |
-| NumberOfInvertersToQuery | Number of Inverters to query. Set a value larger than "0" when not all inverters should be considered. [^1] |
+| NumberOfInvertersToQuery | Number of Inverters to query. Set a value larger than "0" when not all inverters should be considered. *1 |
 | useYieldDay | send YieldDay instead of YieldTotal. Set this to 1 to prevent VRM from adding the total value to the history on one day. E.g. if you don't start using the inverter at 0. |
 | ESP8266PollingIntervall |  For ESP8266 reduce polling intervall to reduce load, default 10000ms|
 | Logging | Valid options for log level: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET, to keep logfile small use ERROR or CRITICAL |
@@ -101,7 +101,7 @@ Within the project there is a file `/data/dbus-opendtu/config.ini`. Most importa
 | Username | use if authentication required, leave empty if no authentication needed |
 | Password | use if authentication required, leave empty if no authentication needed |
 
-[^1] Please assure that the order is correct in the DTU, we can only extract the first one in a row.
+*1 Please assure that the order is correct in the DTU, we can only extract the first one in a row.
 
 #### Inverter options
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Within the project there is a file `/data/dbus-opendtu/config.ini`. Most importa
 | SignOfLifeLog  | Time in minutes how often a status is added to the log-file `current.log` with log-level INFO |
 | NumberOfTemplates | Number ob Template Inverter to query |
 | DTU | Which DTU to be used ahoy, opendtu or template REST devices Valid options: opendtu, ahoy, template |
-| QueryOnlyFirstOfDTUInverter | Amount of Inverters you to query. Set a value larger than "0" when not all inverters should be considered. Please assure that the order is correct in the DTU, we can only extract the first one in a row. |
+| NumberOfInvertersToQuery | Number of Inverters to query. Set a value larger than "0" when not all inverters should be considered. [^1] |
 | useYieldDay | send YieldDay instead of YieldTotal. Set this to 1 to prevent VRM from adding the total value to the history on one day. E.g. if you don't start using the inverter at 0. |
 | ESP8266PollingIntervall |  For ESP8266 reduce polling intervall to reduce load, default 10000ms|
 | Logging | Valid options for log level: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET, to keep logfile small use ERROR or CRITICAL |
@@ -100,6 +100,8 @@ Within the project there is a file `/data/dbus-opendtu/config.ini`. Most importa
 | HTTPTimeout | Timeout when doing the HTTP request to the DTU or template. Default: 2.5 sec |
 | Username | use if authentication required, leave empty if no authentication needed |
 | Password | use if authentication required, leave empty if no authentication needed |
+
+[^1] Please assure that the order is correct in the DTU, we can only extract the first one in a row.
 
 #### Inverter options
 

--- a/config.ini
+++ b/config.ini
@@ -34,6 +34,10 @@ HTTPTimeout=2.5
 Username =
 Password =
 
+# Number of inverters if not all from json response should be used 
+# (0=compute number from json response; > 0 use only first x inverters) 
+NumberOfInverters = 0
+
 ### Only needed for OpenDTU and ahoy
 # AcPosition 0=AC input 1; 1=AC output; 2=AC output 2
 # 1st inverter

--- a/config.ini
+++ b/config.ini
@@ -8,6 +8,11 @@ NumberOfTemplates=0
 # Which DTU to be used ahoy, opendtu, template
 DTU=opendtu
 
+# If you want to exclude Inverter, specify how many of the Inverters you want to query.
+# Please assure that the order is correct in the DTU, we can only extract the first one in a row.
+# (0=compute number from json response; > 0 use only first x inverters) 
+QueryOnlyFirstOfDTUInverter = 0
+
 # send YieldDay instead of YieldTotal
 useYieldDay=0
 
@@ -33,10 +38,6 @@ HTTPTimeout=2.5
 # Username/Password leave empty if no authentication is required
 Username =
 Password =
-
-# Number of inverters if not all from json response should be used 
-# (0=compute number from json response; > 0 use only first x inverters) 
-NumberOfInverters = 0
 
 ### Only needed for OpenDTU and ahoy
 # AcPosition 0=AC input 1; 1=AC output; 2=AC output 2

--- a/config.ini
+++ b/config.ini
@@ -11,7 +11,7 @@ DTU=opendtu
 # If you want to exclude Inverter, specify how many of the Inverters you want to query.
 # Please assure that the order is correct in the DTU, we can only extract the first one in a row.
 # (0=compute number from json response; > 0 use only first x inverters) 
-QueryOnlyFirstOfDTUInverter = 0
+NumberOfInvertersToQuery = 0
 
 # send YieldDay instead of YieldTotal
 useYieldDay=0

--- a/dbus-opendtu.py
+++ b/dbus-opendtu.py
@@ -33,7 +33,7 @@ def main():
     config.read(f"{(os.path.dirname(os.path.realpath(__file__)))}/config.ini")
     logging_level = config["DEFAULT"]["Logging"].upper()
     dtuvariant = config["DEFAULT"]["DTU"]
-    number_of_inverters = int(config["DEFAULT"]["NumberOfInverters"])
+    number_of_inverters = int(config["DEFAULT"]["QueryOnlyFirstOfDTUInverter"])
 
     try:
         number_of_templates = int(config["DEFAULT"]["NumberOfTemplates"])

--- a/dbus-opendtu.py
+++ b/dbus-opendtu.py
@@ -33,7 +33,7 @@ def main():
     config.read(f"{(os.path.dirname(os.path.realpath(__file__)))}/config.ini")
     logging_level = config["DEFAULT"]["Logging"].upper()
     dtuvariant = config["DEFAULT"]["DTU"]
-    number_of_inverters = int(config["DEFAULT"]["QueryOnlyFirstOfDTUInverter"])
+    number_of_inverters = int(config["DEFAULT"]["NumberOfInvertersToQuery"])
 
     try:
         number_of_templates = int(config["DEFAULT"]["NumberOfTemplates"])

--- a/dbus-opendtu.py
+++ b/dbus-opendtu.py
@@ -33,6 +33,7 @@ def main():
     config.read(f"{(os.path.dirname(os.path.realpath(__file__)))}/config.ini")
     logging_level = config["DEFAULT"]["Logging"].upper()
     dtuvariant = config["DEFAULT"]["DTU"]
+    number_of_inverters = int(config["DEFAULT"]["NumberOfInverters"])
 
     try:
         number_of_templates = int(config["DEFAULT"]["NumberOfTemplates"])
@@ -112,7 +113,8 @@ def main():
                 actual_inverter=0,
             )
 
-            number_of_inverters = service.get_number_of_inverters()
+            if number_of_inverters == 0: 
+                number_of_inverters = service.get_number_of_inverters()
 
             if number_of_inverters > 1:
                 # start our main-service if there are more than 1 inverter


### PR DESCRIPTION
First of all I wan't to thank for the great work and valueable project. Well done!

In my case I have a lot of inverters defined in OpenDTU but not all of them should be forwarded to Venus OS.
My apporach is to define the amount of inverters in the config.ini file which should be forwarded.

It is totally backward compatible with the current solution as a value of 0 extracts the amount from the JSON response.

Another, but more complex solution, is to add an additional parameter to the inverter section with the advantage that the inverters to be taken into account do not necessarily have to be at the beginning.
A discussion about that is appreciated.