### PR TITLE
Set StatusCode to 7

### DIFF
--- a/dbus_service.py
+++ b/dbus_service.py
@@ -117,7 +117,7 @@ class DbusService:
         self._dbusservice.add_path("/Position", self.acposition)  # normaly only needed for pvinverter
         self._dbusservice.add_path("/Serial", self._get_serial(self.pvinverternumber))
         self._dbusservice.add_path("/UpdateIndex", 0)
-        self._dbusservice.add_path("/StatusCode", 0)  # Dummy path so VRM detects us as a PV-inverter.
+        self._dbusservice.add_path("/StatusCode", 7)  # Dummy path so VRM detects us as a PV-inverter.
 
         # If the Servicname is an (AC-)Inverter, add the Mode path (to show it as ON)
         # Also, we will set different paths and variables in the _update(self) method.


### PR DESCRIPTION
A couple of days after updating my CerboGX to beta 3.50~13 I recognized that vrm portal does not record the production from the opendtu inverters any more in the  long-term history.
The StatusCode, which seemed to be irrelevant up to now, also now appears within the UI of the console
<img width="509" alt="image" src="https://github.com/user-attachments/assets/a57d6319-3132-4887-8dbd-77892348aff3">
Therefore I changed the static StatusCode from 0 to 7 in the code and since than the inverter production gets logged again in VRM portal.
