### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,7 @@
 name: Pylint
 
+permissions:
+  contents: read
 on: [push, fork]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/henne49/dbus-opendtu/security/code-scanning/19](https://github.com/henne49/dbus-opendtu/security/code-scanning/19)

To fix the problem, you should add a `permissions` key with the minimal required permissions to the workflow. Since this workflow only checks out code and runs linting, it does not need write access to repository contents, pull requests, or other privileged operations. The best practice is to add `permissions: contents: read` at the top level of the workflow file (before or after the `on` key), applying the restriction to all jobs in the workflow. No changes to imports or existing steps are necessary; only a single YAML key needs to be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
