### PR TITLE
Add support for OpenDTU power-limit control, improved status 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project purpose
+
+Python service that bridges Hoymiles inverters (via [OpenDTU](https://github.com/tbnobody/OpenDTU) or [AhoyDTU](https://github.com/lumapu/ahoy)) and generic REST devices (Shelly, Tasmota) into Victron's Venus OS over DBus. Deployed on GX devices under `/data/dbus-opendtu/` and supervised by daemontools.
+
+## Runtime environment matters
+
+- The target runtime is **Venus OS**, not the dev machine. `dbus_service.py` imports `vedbus` from `/opt/victronenergy/dbus-systemcalc-py/ext/velib_python` (path injected via `sys.path.insert`). That module is not available outside Venus OS / the devcontainer, so running `dbus_opendtu.py` locally fails.
+- Tests mock around dbus by using `servicename="testing"` in [`DbusService.__init__`](dbus_service.py#L66-L70), which short-circuits dbus registration. Any new test must use this path.
+- Python 2/3 dual-support for `gobject`/`GLib` lives in [imports.py](imports.py) — don't remove the branch.
+- CI targets **Python 3.8** ([.github/workflows/pylint.yml](.github/workflows/pylint.yml)).
+
+## Commands
+
+```bash
+# Run tests (unittest discovery, no pytest)
+python -m unittest discover -s tests -p "test_*.py"
+
+# Run a single test
+python -m unittest tests.test_dbus_service.TestDbusService.test_name
+
+# Coverage (uses python3-coverage, i.e. Debian/Venus OS package naming)
+./run_coverage.sh
+
+# Lint (CI threshold: --fail-under=8.5)
+pylint $(git ls-files '*.py')
+```
+
+Max line length is 120 ([.vscode/settings.json](.vscode/settings.json), autopep8).
+
+On the target device:
+- `install.sh` — sym-links [service/](service/) into `/service/$SERVICE_NAME`, appends itself to `/data/rc.local` for boot persistence. Requires `config.ini` to exist (copy [config.example](config.example)).
+- `restart.sh` / `uninstall.sh` — kill the supervised python process / remove the service.
+- `update.sh` — interactive download of a release from GitHub; writes into the same folder.
+
+## Architecture
+
+Single-process, event-loop driven:
+
+1. [dbus_opendtu.py](dbus_opendtu.py) is the entry point. It reads `config.ini`, constructs one `DbusService` per inverter + per template, then starts a `GLib.MainLoop` with two periodic timers: `update_all_services` (1 s tick, self-throttled per service) and `sign_of_life_all_services` (minutes, just logs).
+2. Each [`DbusService`](dbus_service.py) instance owns one `VeDbusService` on the bus (`{servicename}.http_{DeviceInstance}`). It fetches JSON from the DTU's REST API, extracts values, and pushes them to the DBus paths declared in [`constants.VICTRON_PATHS`](constants.py#L21-L43).
+3. **Shared fetch optimization:** when multiple inverters are behind one DTU, only `pvinverternumber == 0` actually calls the HTTP API ([`_refresh_data`](dbus_service.py#L385-L402)). The JSON is cached on the class via `DbusService._meter_data` and all instances read from there. Templates bypass this — each has its own `self.meter_data`.
+4. **Three DTU modes** (`DEFAULT.DTU` in config): `opendtu`, `ahoy`, `template`. `ahoy`/`opendtu` and `template` can coexist — templates are always iterated on top. The mode drives URL shape, JSON parsing, and the polling interval (5 s for OpenDTU, 5 s or `ESP8266PollingIntervall` for Ahoy depending on ESP type, configurable for templates).
+5. **Error handling** has two modes (`ErrorMode`): `retrycount` (zero values + StatusCode=10 after N consecutive failures) and `timeout` (zero values only after `ErrorStateAfterSeconds` without any success). See README "Error Handling Modes" — both modes share `RetryAfterSeconds` for reconnect cadence.
+6. **Three-phase split:** if `Phase=3P`, reported total power/current/energy is divided across L1/L2/L3 (Hoymiles three-phase micros only report totals). Otherwise values land on the single configured phase.
+7. **Service types:** `com.victronenergy.pvinverter` is the normal path. `com.victronenergy.inverter` (battery inverter / non-PV) is BETA and adds `/Mode` and `/State` paths ([dbus_service.py:135-143](dbus_service.py#L135-L143)).
+
+## Details on OpenDTU API
+[OpenDTU API](https://www.opendtu.solar/firmware/web_api/)
+
+## Configuration
+
+- `config.ini` is required at runtime and is **gitignored**. [config.example](config.example) is the authoritative template — update it in lockstep with any new config key.
+- Helpers [`get_config_value`](helpers.py#L33) and [`get_default_config`](helpers.py#L45) wrap lookups; `get_config_value` raises for missing keys in `INVERTER*` sections (no silent defaults there).
+- Template `CUST_*` path keys are slash-separated paths into the JSON, consumed by [`get_value_by_path`](helpers.py#L53) which falls back to integer-indexing for array steps.
+
+## Tests and fixtures
+
+- JSON fixtures under [docs/](docs/) are test data, not user docs — every supported DTU variant/version has a captured sample (e.g. `ahoy_0.5.93_live.json`, `opendtu_v24.2.12_livedata_status.json`, `tasmota_shelly_2pm.json`). Add a new fixture when adding support for a new DTU firmware shape.
+- [tests.py](tests.py) is a legacy in-process test runner that's disabled in `main()`. New tests belong in [tests/](tests/) using `unittest`.
+- `tests/test_dbus_service.py` mocks `requests.get` (see `mocked_requests_get`) to return fixture JSON — follow that pattern for new HTTP-dependent tests.
+
+## Versioning
+
+Version is tracked in [version.txt](version.txt) (format: `Version: X.Y.Z`) and read at startup by [`read_version`](helpers.py#L129) to populate `/FirmwareVersion` on DBus. GitHub Actions (`.github/workflows/version.yml`) bumps it on release. `install.sh` has version-gated cleanup logic for migrations across 2.0.0.

--- a/constants.py
+++ b/constants.py
@@ -10,20 +10,50 @@ CONNECTION = "TCP/IP (HTTP)"
 MODE_TIMEOUT = "timeout"
 MODE_RETRYCOUNT = "retrycount"
 
-# Status codes for the DTU
+# /StatusCode values shared by com.victronenergy.pvinverter and .inverter
+# 0..6 = Startup, 7 = Running, 8 = Standby, 9 = Boot loading, 10 = Error
 STATUSCODE_STARTUP = 0
 STATUSCODE_RUNNING = 7
 STATUSCODE_STANDBY = 8
 STATUSCODE_BOOTLOADING = 9
 STATUSCODE_ERROR = 10
 
+# ---------------------------------------------------------------------------
+# com.victronenergy.pvinverter DBus schema
+# (https://github.com/victronenergy/venus/wiki/dbus#pv-inverters)
+#
+# Published via PVINVERTER_PATHS (registered in the add_path loop):
+#   /Ac/Energy/Forward      kWh   Total produced energy over all phases
+#   /Ac/Power               W     Total real power across all phases
+#   /Ac/L<n>/Voltage        V AC
+#   /Ac/L<n>/Current        A AC
+#   /Ac/L<n>/Power          W
+#   /Ac/L<n>/Energy/Forward kWh
+#   /Ac/MaxPower            W     Max rated power of the inverter
+#   /Ac/PowerLimit          W     Fronius zero-feed-in setpoint. Must be absent
+#                                  for PV inverters without power-limit support;
+#                                  VictronConnect-set user limit still caps it.
+#
+# Deprecated (do not use):
+#   /Ac/Current, /Ac/Voltage
+#
+# Published directly in dbus_service.py __init__:
+#   /Position               0 = AC input 1, 1 = AC output, 2 = AC input 2
+#   /PositionIsAdjustable   0 = not adjustable, 1 = adjustable
+#   /StatusCode             see STATUSCODE_* above
+#
+# Optional (not implemented here):
+#   /ErrorCode              0 = No Error
+#   /FroniusDeviceType      Fronius-specific product id
+#   /IsGenericEnergyMeter   1 = PV inverter is provided by a generic energy
+#                             meter (no power-limit support)
+# ---------------------------------------------------------------------------
 
-VICTRON_PATHS = {
-    "/Ac/Energy/Forward": {
-        "initial": None,
-        "textformat": _kwh,
-    },  # energy produced by pv inverter
+PVINVERTER_PATHS = {
+    "/Ac/Energy/Forward": {"initial": None, "textformat": _kwh},
     "/Ac/Power": {"initial": None, "textformat": _w},
+    "/Ac/MaxPower": {"initial": None, "textformat": _w},
+    "/Ac/PowerLimit": {"initial": None, "textformat": _w},
     "/Ac/L1/Voltage": {"initial": None, "textformat": _v},
     "/Ac/L2/Voltage": {"initial": None, "textformat": _v},
     "/Ac/L3/Voltage": {"initial": None, "textformat": _v},
@@ -36,8 +66,14 @@ VICTRON_PATHS = {
     "/Ac/L1/Energy/Forward": {"initial": None, "textformat": _kwh},
     "/Ac/L2/Energy/Forward": {"initial": None, "textformat": _kwh},
     "/Ac/L3/Energy/Forward": {"initial": None, "textformat": _kwh},
+}
+
+# Superset used by com.victronenergy.inverter (battery inverter). Adds the
+# Ac/Out/* and Dc/0/Voltage paths that the inverter service reports on.
+VICTRON_PATHS = dict(PVINVERTER_PATHS)
+VICTRON_PATHS.update({
     "/Ac/Out/L1/I": {"initial": None, "textformat": _a},
     "/Ac/Out/L1/V": {"initial": None, "textformat": _v},
     "/Ac/Out/L1/P": {"initial": None, "textformat": _w},
     "/Dc/0/Voltage": {"initial": None, "textformat": _v},
-}
+})

--- a/constants.py
+++ b/constants.py
@@ -40,8 +40,6 @@ STATUSCODE_ERROR = 10
 # Published directly in dbus_service.py __init__:
 #   /Position               0 = AC input 1, 1 = AC output, 2 = AC input 2
 #   /PositionIsAdjustable   0 = not adjustable, 1 = adjustable
-#   /NrOfPhases             int   Number of AC phases (1 or 3)
-#   /PhaseConfig            "1P" or "3P" — derived from config Phase
 #   /StatusCode             see STATUSCODE_* above
 #
 # Optional (not implemented here):

--- a/constants.py
+++ b/constants.py
@@ -40,6 +40,8 @@ STATUSCODE_ERROR = 10
 # Published directly in dbus_service.py __init__:
 #   /Position               0 = AC input 1, 1 = AC output, 2 = AC input 2
 #   /PositionIsAdjustable   0 = not adjustable, 1 = adjustable
+#   /NrOfPhases             int   Number of AC phases (1 or 3)
+#   /PhaseConfig            "1P" or "3P" — derived from config Phase
 #   /StatusCode             see STATUSCODE_* above
 #
 # Optional (not implemented here):

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -157,8 +157,6 @@ class DbusService:
         if servicename == "com.victronenergy.pvinverter":
             self._dbusservice.add_path("/Position", self.acposition)
             self._dbusservice.add_path("/PositionIsAdjustable", 1)
-            self._dbusservice.add_path("/NrOfPhases", 3 if self.pvinverterphase == "3P" else 1,)
-            self._dbusservice.add_path("/PhaseConfig", "3P" if self.pvinverterphase == "3P" else "1P")
 
         # If the Servicname is an (AC-)Inverter, add the Mode path (to show it as ON)
         # Also, we will set different paths and variables in the _update(self) method.

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -738,18 +738,21 @@ class DbusService:
         return True
 
     def _compute_status_code(self):
-        '''Map inverter reachable/producing state onto STATUSCODE_* (7/8/10).'''
+        '''Map inverter reachable/producing state onto STATUSCODE_* (7/8/10).
+           OpenDTU reachable=false means the HTTP fetch succeeded but the
+           inverter itself is silent (typically night) -> Standby, not Error.
+           HTTP-failure paths still flag Error via set_dbus_values_to_zero().'''
         try:
-            if not self.is_data_up2date():
-                return constants.STATUSCODE_ERROR
             meter_data = self._get_data()
             if self.dtuvariant == constants.DTUVARIANT_OPENDTU:
                 inv = meter_data["inverters"][self.pvinverternumber]
                 if not is_true(inv.get("reachable")):
-                    return constants.STATUSCODE_ERROR
+                    return constants.STATUSCODE_STANDBY
                 if is_true(inv.get("producing")):
                     return constants.STATUSCODE_RUNNING
                 return constants.STATUSCODE_STANDBY
+            if not self.is_data_up2date():
+                return constants.STATUSCODE_ERROR
             if self.dtuvariant == constants.DTUVARIANT_AHOY:
                 power = get_ahoy_field_by_name(meter_data, self.pvinverternumber, "P_AC")
                 if power and float(power) > 0:

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -157,6 +157,8 @@ class DbusService:
         if servicename == "com.victronenergy.pvinverter":
             self._dbusservice.add_path("/Position", self.acposition)
             self._dbusservice.add_path("/PositionIsAdjustable", 1)
+            self._dbusservice.add_path("/NrOfPhases", 3 if self.pvinverterphase == "3P" else 1,)
+            self._dbusservice.add_path("/PhaseConfig", "3P" if self.pvinverterphase == "3P" else "1P")
 
         # If the Servicname is an (AC-)Inverter, add the Mode path (to show it as ON)
         # Also, we will set different paths and variables in the _update(self) method.

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -12,6 +12,7 @@ import platform
 import sys
 import logging
 import time
+from json import dumps as json_dumps
 import requests  # for http GET
 from requests.auth import HTTPDigestAuth
 
@@ -103,30 +104,48 @@ class DbusService:
         )
 
         self._dbusservice = VeDbusService(f"{servicename}.http_{self.deviceinstance}", bus=dbus_conn, register=False)
-        self._paths = constants.VICTRON_PATHS
+        self._paths = (constants.PVINVERTER_PATHS
+                       if servicename == "com.victronenergy.pvinverter"
+                       else constants.VICTRON_PATHS)
 
         # Create the management objects, as specified in the ccgx dbus-api document
         self._dbusservice.add_path("/Mgmt/ProcessName", __file__)
         self._dbusservice.add_path("/Mgmt/ProcessVersion",
                                    "Unkown version, and running on Python " + platform.python_version())
-        self._dbusservice.add_path("/Mgmt/Connection", constants.CONNECTION)
+        self._dbusservice.add_path("/Mgmt/Connection", constants.PRODUCTNAME + " - " + constants.CONNECTION)
+
+        # Fetch serial + OpenDTU devinfo once so management paths can be populated
+        # with real hardware/firmware metadata instead of placeholders.
+        self.serial = self._get_serial(self.pvinverternumber)
+        self.devinfo = self._fetch_devinfo_safe()
+
+        product_name = (self.devinfo.get("hw_model_name") if self.devinfo else None) or self._get_name()
+        firmware_version = self._format_firmware_version() or read_version('version.txt')
+        hardware_version = self._decode_version(
+            self.devinfo.get("hw_version") if self.devinfo else None) or 0
+        initial_status = (constants.STATUSCODE_ERROR
+                          if self.devinfo is not None and not is_true(self.devinfo.get("valid_data", True))
+                          else constants.STATUSCODE_STARTUP)
 
         # Create the mandatory objects
         self._dbusservice.add_path("/DeviceInstance", self.deviceinstance)
         self._dbusservice.add_path("/ProductId", 0xFFFF)  # id assigned by Victron Support from SDM630v2.py
-        self._dbusservice.add_path("/ProductName", constants.PRODUCTNAME)
+        self._dbusservice.add_path("/ProductName", product_name)
         self._dbusservice.add_path("/CustomName", self._get_name())
         logging.info(f"Name of Inverters found: {self._get_name()}")
         self._dbusservice.add_path("/Connected", 1)
 
         self._dbusservice.add_path("/Latency", None)
-        self._dbusservice.add_path("/FirmwareVersion", read_version('version.txt'))
-        self._dbusservice.add_path("/HardwareVersion", 0)
-        self._dbusservice.add_path("/Position", self.acposition)  # normaly only needed for pvinverter
-        self._dbusservice.add_path("/Serial", self._get_serial(self.pvinverternumber))
+        self._dbusservice.add_path("/FirmwareVersion", firmware_version)
+        self._dbusservice.add_path("/HardwareVersion", hardware_version)
+        self._dbusservice.add_path("/Serial", self.serial)
         self._dbusservice.add_path("/UpdateIndex", 0)
-        # set path StatusCode to 7=Running so VRM detects a working PV-Inverter
-        self._dbusservice.add_path("/StatusCode", constants.STATUSCODE_RUNNING)
+        # StatusCode starts at Startup(0); first successful update_dbus_values() transitions to Running/Standby.
+        # devinfo.valid_data=false at startup already flags ERROR.
+        self._dbusservice.add_path("/StatusCode", initial_status)
+        if servicename == "com.victronenergy.pvinverter":
+            self._dbusservice.add_path("/Position", self.acposition)
+            self._dbusservice.add_path("/PositionIsAdjustable", 1)
 
         # If the Servicname is an (AC-)Inverter, add the Mode path (to show it as ON)
         # Also, we will set different paths and variables in the _update(self) method.
@@ -154,6 +173,11 @@ class DbusService:
 
         self._dbusservice.register()
 
+        try:
+            self._refresh_limit_status()
+        except Exception as error:
+            logging.warning(f"Initial limit status fetch failed: {error}")
+
         self.polling_interval = self._get_polling_interval()
         self.last_polling = 0
 
@@ -170,9 +194,10 @@ class DbusService:
             ac_inverter_state = 0  # = Off
         return ac_inverter_state
 
-    @staticmethod
-    def _handlechangedvalue(path, value):
+    def _handlechangedvalue(self, path, value):
         logging.debug("someone else updated %s to %s", path, value)
+        if path == "/Ac/PowerLimit" and self.dtuvariant == constants.DTUVARIANT_OPENDTU:
+            return self._apply_power_limit(value)
         return True  # accept the change
 
     @staticmethod
@@ -446,6 +471,99 @@ class DbusService:
         logging.debug(f"Inverter URL: {iv_url}")
         return self.fetch_url(iv_url)
 
+    def fetch_opendtu_devinfo(self, inverter_serial):
+        '''Fetch device info (firmware/hardware metadata) from OpenDTU for one inverter.'''
+        url = f"{self.get_opendtu_base_url()}/devinfo/status?inv={inverter_serial}"
+        logging.debug(f"Devinfo URL: {url}")
+        return self.fetch_url(url)
+
+    def _fetch_devinfo_safe(self):
+        '''OpenDTU only: one-shot devinfo fetch at startup. Returns dict or None on failure.'''
+        if self.dtuvariant != constants.DTUVARIANT_OPENDTU:
+            return None
+        try:
+            return self.fetch_opendtu_devinfo(self.serial)
+        except Exception as error:
+            logging.warning(f"devinfo fetch failed: {error}")
+            return None
+
+    @staticmethod
+    def _decode_version(value):
+        '''Decode OpenDTU version fields. Strings pass through; ints are split into
+           2-digit groups from the right (e.g. 10027 -> "1.0.27", 101 -> "0.1.1").'''
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, int):
+            return f"{value // 10000}.{(value // 100) % 100}.{value % 100}"
+        return str(value)
+
+    def _format_firmware_version(self):
+        '''Combine devinfo fw_build_version and fw_build_datetime into a display string.'''
+        if not self.devinfo:
+            return None
+        fw_ver = self._decode_version(self.devinfo.get("fw_build_version"))
+        fw_dt = self.devinfo.get("fw_build_datetime")
+        if fw_ver and fw_dt:
+            return f"{fw_ver} ({fw_dt})"
+        return fw_ver or fw_dt
+
+    def _refresh_limit_status(self):
+        '''OpenDTU only: fetch /api/limit/status, publish /Ac/MaxPower,
+           and mirror limit_set_status to /StatusCode.'''
+        if self.dtuvariant != constants.DTUVARIANT_OPENDTU:
+            return
+        url = f"{self.get_opendtu_base_url()}/limit/status"
+        status = self.fetch_url(url)
+        entry = status.get(self.serial)
+        if not entry:
+            logging.warning(f"No limit status entry for serial {self.serial}")
+            return
+        max_power = entry.get("max_power")
+        limit_relative = entry.get("limit_relative")
+        if max_power is not None:
+            self._dbusservice["/Ac/MaxPower"] = max_power
+            if limit_relative is not None and self._dbusservice["/Ac/PowerLimit"] is None:
+                self._dbusservice["/Ac/PowerLimit"] = max_power * float(limit_relative) / 100.0
+        limit_set_status = entry.get("limit_set_status")
+        if limit_set_status == "Ok":
+            self._dbusservice["/StatusCode"] = constants.STATUSCODE_RUNNING
+        else:
+            logging.warning(f"limit_set_status={limit_set_status} for serial {self.serial}")
+            self._dbusservice["/StatusCode"] = constants.STATUSCODE_ERROR
+
+    def _apply_power_limit(self, watts):
+        '''Write /Ac/PowerLimit -> POST /api/limit/config (absolute watts, non-persistent).
+           Return True to accept the DBus write, False to reject.'''
+        try:
+            watts_int = int(watts)
+        except (TypeError, ValueError):
+            logging.warning(f"Rejecting non-numeric PowerLimit write: {watts!r}")
+            return False
+        if watts_int < 0:
+            logging.warning(f"Rejecting negative PowerLimit write: {watts_int}")
+            return False
+        max_power = self._dbusservice["/Ac/MaxPower"]
+        if max_power and watts_int > max_power:
+            logging.debug(f"Clamping PowerLimit {watts_int}W to MaxPower {max_power}W")
+            watts_int = int(max_power)
+        payload = {"serial": self.serial, "limit_type": 0, "limit_value": watts_int}
+        url = f"{self.get_opendtu_base_url()}/limit/config"
+        try:
+            response = self.post_url(url, payload)
+        except Exception as error:
+            logging.warning(f"Failed to apply power limit: {error}")
+            return False
+        if response.get("type") != "success":
+            logging.warning(f"OpenDTU rejected limit: {response}")
+            return False
+        try:
+            self._refresh_limit_status()
+        except Exception as error:
+            logging.warning(f"Post-write limit status refresh failed: {error}")
+        return True
+
     def fetch_ahoy_iv_data(self, inverter_number):
         '''Fetch inverter data from Ahoy device for one inverter'''
         iv_url = self.get_ahoy_base_url() + "/inverter/id/" + str(inverter_number)
@@ -500,6 +618,21 @@ class DbusService:
             else:
                 raise
 
+    def post_url(self, url, payload):
+        '''POST payload to url wrapped as form field data=<json>. Return parsed JSON response.'''
+        form = {"data": json_dumps(payload)}
+        logging.debug(f"POST {url} with payload={payload}")
+        if self.digestauth:
+            response = requests.post(url=url, data=form, auth=HTTPDigestAuth(
+                self.username, self.password), timeout=float(self.httptimeout))
+        elif self.username and self.password:
+            response = requests.post(url=url, data=form, auth=(
+                self.username, self.password), timeout=float(self.httptimeout))
+        else:
+            response = requests.post(url=url, data=form, timeout=float(self.httptimeout))
+        response.raise_for_status()
+        return response.json()
+
     def _get_data(self) -> dict:
         if self._test_meter_data:
             return self._test_meter_data
@@ -537,6 +670,28 @@ class DbusService:
         if self.dtuvariant == constants.DTUVARIANT_OPENDTU:
             return is_true(meter_data["inverters"][self.pvinverternumber]["reachable"])
         return True
+
+    def _compute_status_code(self):
+        '''Map inverter reachable/producing state onto STATUSCODE_* (7/8/10).'''
+        try:
+            meter_data = self._get_data()
+            if self.dtuvariant == constants.DTUVARIANT_OPENDTU:
+                inv = meter_data["inverters"][self.pvinverternumber]
+                if not is_true(inv.get("reachable")):
+                    return constants.STATUSCODE_ERROR
+                if is_true(inv.get("producing")):
+                    return constants.STATUSCODE_RUNNING
+                return constants.STATUSCODE_STANDBY
+            if self.dtuvariant == constants.DTUVARIANT_AHOY:
+                power = get_ahoy_field_by_name(meter_data, self.pvinverternumber, "P_AC")
+                if power and float(power) > 0:
+                    return constants.STATUSCODE_RUNNING
+                return constants.STATUSCODE_STANDBY
+            # TEMPLATE: best-effort; assume running when data is up to date
+            return constants.STATUSCODE_RUNNING
+        except Exception as error:
+            logging.debug(f"_compute_status_code fallback to ERROR: {error}")
+            return constants.STATUSCODE_ERROR
 
     def get_ts_last_success(self, meter_data):
         '''return ts_last_success from the meter_data structure - depending on the API version'''
@@ -649,7 +804,7 @@ class DbusService:
     def _finalize_update(self, successful):
         if successful:
             if self.reset_statuscode_on_next_success:
-                self._dbusservice["/StatusCode"] = constants.STATUSCODE_RUNNING
+                self._dbusservice["/StatusCode"] = self._compute_status_code()
             if not self.last_update_successful:
                 logging.warning(
                     f"Recovered inverter {self.pvinverternumber} ({self._get_name()}): "
@@ -840,3 +995,5 @@ class DbusService:
             logging.debug(f"Inverter #{self.pvinverternumber} Power (/Ac/Power): {power}")
             logging.debug(f"Inverter #{self.pvinverternumber} Energy (/Ac/Energy/Forward): {pvyield}")
             logging.debug("---")
+
+        self._dbusservice["/StatusCode"] = self._compute_status_code()

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -674,6 +674,8 @@ class DbusService:
     def _compute_status_code(self):
         '''Map inverter reachable/producing state onto STATUSCODE_* (7/8/10).'''
         try:
+            if not self.is_data_up2date():
+                return constants.STATUSCODE_ERROR
             meter_data = self._get_data()
             if self.dtuvariant == constants.DTUVARIANT_OPENDTU:
                 inv = meter_data["inverters"][self.pvinverternumber]
@@ -714,11 +716,13 @@ class DbusService:
 
     def _refresh_and_update(self):
         """
-        Helper method to refresh data, handle data update if up-to-date, update index, and set successful flag.
+        Refresh data and publish it regardless of reachability/age. When the inverter
+        is offline (OpenDTU reachable=false, or Ahoy data older than max_age_ts)
+        we still want cumulative values (Energy/Forward) on DBus and /StatusCode
+        set to ERROR via _compute_status_code.
         """
         self._refresh_data()
-        if self.is_data_up2date():
-            self._handle_data_update()
+        self._handle_data_update()
         self._update_index()
         return True
 
@@ -976,7 +980,9 @@ class DbusService:
                 self._dbusservice["/Ac/L3/Power"] = powerthird
                 self._dbusservice["/Ac/Power"] = power
 
-                if power > 0:
+                # Energy/Forward is cumulative; publish every cycle so totals stay visible
+                # while the inverter is offline (e.g. at night).
+                if pvyield is not None:
                     self._dbusservice["/Ac/L1/Energy/Forward"] = pvyield / 3
                     self._dbusservice["/Ac/L2/Energy/Forward"] = pvyield / 3
                     self._dbusservice["/Ac/L3/Energy/Forward"] = pvyield / 3
@@ -988,7 +994,7 @@ class DbusService:
                 self._dbusservice[pre + "/Current"] = current
                 self._dbusservice[pre + "/Power"] = power
                 self._dbusservice["/Ac/Power"] = power
-                if power > 0:
+                if pvyield is not None:
                     self._dbusservice[pre + "/Energy/Forward"] = pvyield
                     self._dbusservice["/Ac/Energy/Forward"] = pvyield
 

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -118,6 +118,14 @@ class DbusService:
         # with real hardware/firmware metadata instead of placeholders.
         self.serial = self._get_serial(self.pvinverternumber)
         self.devinfo = self._fetch_devinfo_safe()
+        # Seed /Ac/MaxPower and /Ac/PowerLimit from OpenDTU before add_path; writing
+        # them later would emit PropertiesChanged and round-trip back as an external
+        # Set that our onchangecallback re-applies to OpenDTU, stomping on user limits.
+        limit_entry = self._fetch_limit_entry_safe()
+        initial_max_power, initial_power_limit = self._initial_power_limit_from_entry(limit_entry)
+        # If the initial fetch failed, _refresh_limit_status will seed these paths
+        # on its first successful call. Track the state so the seed fires at most once.
+        self._limit_seeded = limit_entry is not None
 
         product_name = (self.devinfo.get("hw_model_name") if self.devinfo else None) or self._get_name()
         firmware_version = self._format_firmware_version() or read_version('version.txt')
@@ -127,15 +135,18 @@ class DbusService:
                           if self.devinfo is not None and not is_true(self.devinfo.get("valid_data", True))
                           else constants.STATUSCODE_STARTUP)
 
+        self.polling_interval = self._get_polling_interval()
+
         # Create the mandatory objects
         self._dbusservice.add_path("/DeviceInstance", self.deviceinstance)
         self._dbusservice.add_path("/ProductId", 0xFFFF)  # id assigned by Victron Support from SDM630v2.py
         self._dbusservice.add_path("/ProductName", product_name)
         self._dbusservice.add_path("/CustomName", self._get_name())
         logging.info(f"Name of Inverters found: {self._get_name()}")
-        self._dbusservice.add_path("/Connected", 1)
+        connected = int(is_true(self.devinfo.get("valid_data"))) if self.devinfo else 1
+        self._dbusservice.add_path("/Connected", connected)
 
-        self._dbusservice.add_path("/Latency", None)
+        self._dbusservice.add_path("/Latency", self.polling_interval)
         self._dbusservice.add_path("/FirmwareVersion", firmware_version)
         self._dbusservice.add_path("/HardwareVersion", hardware_version)
         self._dbusservice.add_path("/Serial", self.serial)
@@ -162,10 +173,15 @@ class DbusService:
             self._dbusservice.add_path("/State", 9)
 
         # add path values to dbus
+        initial_overrides = {
+            "/Ac/MaxPower": initial_max_power,
+            "/Ac/PowerLimit": initial_power_limit,
+        }
         for path, settings in self._paths.items():
+            initial_value = initial_overrides.get(path, settings["initial"])
             self._dbusservice.add_path(
                 path,
-                settings["initial"],
+                initial_value,
                 gettextcallback=settings["textformat"],
                 writeable=True,
                 onchangecallback=self._handlechangedvalue,
@@ -173,12 +189,6 @@ class DbusService:
 
         self._dbusservice.register()
 
-        try:
-            self._refresh_limit_status()
-        except Exception as error:
-            logging.warning(f"Initial limit status fetch failed: {error}")
-
-        self.polling_interval = self._get_polling_interval()
         self.last_polling = 0
 
     @staticmethod
@@ -487,6 +497,31 @@ class DbusService:
             logging.warning(f"devinfo fetch failed: {error}")
             return None
 
+    def _fetch_limit_entry_safe(self):
+        '''OpenDTU only: one-shot /api/limit/status fetch for this inverter at startup.
+           Returns the per-serial entry dict or None on failure.'''
+        if self.dtuvariant != constants.DTUVARIANT_OPENDTU:
+            return None
+        try:
+            status = self.fetch_url(f"{self.get_opendtu_base_url()}/limit/status")
+            return status.get(self.serial)
+        except Exception as error:
+            logging.warning(f"limit status fetch failed: {error}")
+            return None
+
+    @staticmethod
+    def _initial_power_limit_from_entry(entry):
+        '''Derive (max_power, power_limit) pair from a /api/limit/status entry.
+           Either value may be None if the entry is missing or incomplete.'''
+        if not entry:
+            return (None, None)
+        max_power = entry.get("max_power")
+        limit_relative = entry.get("limit_relative")
+        power_limit = None
+        if max_power is not None and limit_relative is not None:
+            power_limit = max_power * float(limit_relative) / 100.0
+        return (max_power, power_limit)
+
     @staticmethod
     def _decode_version(value):
         '''Decode OpenDTU version fields. Strings pass through; ints are split into
@@ -510,9 +545,12 @@ class DbusService:
         return fw_ver or fw_dt
 
     def _refresh_limit_status(self):
-        '''OpenDTU only: fetch /api/limit/status, publish /Ac/MaxPower,
-           and mirror limit_set_status to /StatusCode. Returns the limit_set_status
-           string (or None) so callers can poll through a "Pending" phase.'''
+        '''OpenDTU only: fetch /api/limit/status and mirror limit_set_status to
+           /StatusCode. Returns the limit_set_status string (or None) so callers can
+           poll through a "Pending" phase. /Ac/MaxPower and /Ac/PowerLimit are seeded
+           at init via add_path; if that initial fetch failed, this function performs
+           a one-shot fallback seed (guarded by echo suppression in _handlechangedvalue
+           so the internal write doesn't round-trip back as a POST).'''
         if self.dtuvariant != constants.DTUVARIANT_OPENDTU:
             return None
         url = f"{self.get_opendtu_base_url()}/limit/status"
@@ -521,12 +559,15 @@ class DbusService:
         if not entry:
             logging.warning(f"No limit status entry for serial {self.serial}")
             return None
-        max_power = entry.get("max_power")
-        limit_relative = entry.get("limit_relative")
-        if max_power is not None:
-            self._dbusservice["/Ac/MaxPower"] = max_power
-            if limit_relative is not None and self._dbusservice["/Ac/PowerLimit"] is None:
-                self._dbusservice["/Ac/PowerLimit"] = max_power * float(limit_relative) / 100.0
+        if not getattr(self, "_limit_seeded", True):
+            # Mark seeded before writes so any re-entrant _refresh_limit_status (via
+            # onchangecallback -> _apply_power_limit -> _wait_for_limit_settled) skips.
+            self._limit_seeded = True
+            max_power, power_limit = self._initial_power_limit_from_entry(entry)
+            if max_power is not None:
+                self._dbusservice["/Ac/MaxPower"] = max_power
+            if power_limit is not None:
+                self._dbusservice["/Ac/PowerLimit"] = power_limit
         limit_set_status = entry.get("limit_set_status")
         if limit_set_status == "Ok":
             self._dbusservice["/StatusCode"] = constants.STATUSCODE_RUNNING
@@ -747,9 +788,29 @@ class DbusService:
         set to ERROR via _compute_status_code.
         """
         self._refresh_data()
+        self._publish_connected()
         self._handle_data_update()
         self._update_index()
         return True
+
+    def _publish_connected(self):
+        '''OpenDTU only: re-fetch devinfo and publish /Connected = 1 iff both
+           devinfo.valid_data and the livedata inverter.reachable flag are true.
+           self.devinfo is kept current so hardware metadata survives transient errors
+           (we only overwrite it on a successful fetch).'''
+        if self.dtuvariant != constants.DTUVARIANT_OPENDTU:
+            return
+        devinfo = self._fetch_devinfo_safe()
+        if devinfo is not None:
+            self.devinfo = devinfo
+        valid = is_true(self.devinfo.get("valid_data")) if self.devinfo else False
+        reachable = False
+        try:
+            meter_data = self._get_data()
+            reachable = is_true(meter_data["inverters"][self.pvinverternumber].get("reachable"))
+        except Exception as error:
+            logging.debug(f"reachable lookup failed: {error}")
+        self._dbusservice["/Connected"] = int(valid and reachable)
 
     def update(self):
         """

--- a/dbus_service.py
+++ b/dbus_service.py
@@ -511,15 +511,16 @@ class DbusService:
 
     def _refresh_limit_status(self):
         '''OpenDTU only: fetch /api/limit/status, publish /Ac/MaxPower,
-           and mirror limit_set_status to /StatusCode.'''
+           and mirror limit_set_status to /StatusCode. Returns the limit_set_status
+           string (or None) so callers can poll through a "Pending" phase.'''
         if self.dtuvariant != constants.DTUVARIANT_OPENDTU:
-            return
+            return None
         url = f"{self.get_opendtu_base_url()}/limit/status"
         status = self.fetch_url(url)
         entry = status.get(self.serial)
         if not entry:
             logging.warning(f"No limit status entry for serial {self.serial}")
-            return
+            return None
         max_power = entry.get("max_power")
         limit_relative = entry.get("limit_relative")
         if max_power is not None:
@@ -529,9 +530,33 @@ class DbusService:
         limit_set_status = entry.get("limit_set_status")
         if limit_set_status == "Ok":
             self._dbusservice["/StatusCode"] = constants.STATUSCODE_RUNNING
+        elif limit_set_status == "Pending":
+            # Transient: inverter hasn't acknowledged the new limit yet. Leave
+            # /StatusCode unchanged so callers can poll without flapping.
+            logging.debug(f"limit_set_status=Pending for serial {self.serial}")
         else:
             logging.warning(f"limit_set_status={limit_set_status} for serial {self.serial}")
             self._dbusservice["/StatusCode"] = constants.STATUSCODE_ERROR
+        return limit_set_status
+
+    def _wait_for_limit_settled(self, timeout=5.0, interval=0.5):
+        '''Poll _refresh_limit_status until limit_set_status leaves "Pending" or
+           timeout elapses. Returns the final status string (or None).'''
+        deadline = time.time() + timeout
+        status = None
+        while True:
+            try:
+                status = self._refresh_limit_status()
+            except Exception as error:
+                logging.warning(f"Limit status refresh failed during poll: {error}")
+                return status
+            if status != "Pending":
+                return status
+            if time.time() >= deadline:
+                logging.warning(
+                    f"limit_set_status still Pending after {timeout:.1f}s for serial {self.serial}")
+                return status
+            time.sleep(interval)
 
     def _apply_power_limit(self, watts):
         '''Write /Ac/PowerLimit -> POST /api/limit/config (absolute watts, non-persistent).
@@ -559,7 +584,7 @@ class DbusService:
             logging.warning(f"OpenDTU rejected limit: {response}")
             return False
         try:
-            self._refresh_limit_status()
+            self._wait_for_limit_settled()
         except Exception as error:
             logging.warning(f"Post-write limit status refresh failed: {error}")
         return True

--- a/docs/opendtu_devinfo_status.json
+++ b/docs/opendtu_devinfo_status.json
@@ -1,0 +1,11 @@
+{
+    "valid_data": true,
+    "fw_bootloader_version": 101,
+    "fw_build_version": 10027,
+    "hw_part_number": 270692630,
+    "hw_version": "01.10",
+    "hw_model_name": "HMS-2000-4T",
+    "max_power": 2000,
+    "fw_build_datetime": "2023-06-05 10:24:00",
+    "pdl_supported": false
+}

--- a/docs/opendtu_limit_status.json
+++ b/docs/opendtu_limit_status.json
@@ -1,0 +1,12 @@
+{
+    "114182940773": {
+        "limit_relative": 50,
+        "max_power": 2000,
+        "limit_set_status": "Ok"
+    },
+    "114182000001": {
+        "limit_relative": 100,
+        "max_power": 2000,
+        "limit_set_status": "Ok"
+    }
+}

--- a/helpers.py
+++ b/helpers.py
@@ -13,20 +13,29 @@ import logging
 
 
 # region formatting helping functions (used in constant)
-def _kwh(_p, value: float) -> str:
-    return f"{value:.2f}KWh"
+# GetText runs on every SetValue, including writes from external dbus peers
+# (e.g. `dbus -y ... SetValue "100"`). Coerce so a string/None can't raise.
+def _fmt(value, precision: int, suffix: str) -> str:
+    try:
+        return f"{float(value):.{precision}f}{suffix}"
+    except (TypeError, ValueError):
+        return "" if value is None else f"{value}{suffix}"
 
 
-def _a(_p, value: float) -> str:
-    return f"{value:.1f}A"
+def _kwh(_p, value) -> str:
+    return _fmt(value, 2, "KWh")
 
 
-def _w(_p, value: float) -> str:
-    return f"{value:.1f}W"
+def _a(_p, value) -> str:
+    return _fmt(value, 1, "A")
 
 
-def _v(_p, value: float) -> str:
-    return f"{value:.1f}V"
+def _w(_p, value) -> str:
+    return _fmt(value, 1, "W")
+
+
+def _v(_p, value) -> str:
+    return _fmt(value, 1, "V")
 # endregion
 
 

--- a/products.txt
+++ b/products.txt
@@ -1,0 +1,805 @@
+# extracted from vecan-dbus binary using
+# od -i -w8 < ids | grep -m 1 65535 -B 1000 | while read -a REPLY ; do echo ${REPLY[1]} $(dd if=vecan-dbus bs=1 count=60 status=none skip=$((${REPLY[2]}-65536)) | cut -d '' -f1) ; done > products.txt
+1 VPN
+2 VBC
+3 VVC
+4 VCC
+5 VCM
+6 VGM
+7 VRS
+8 Free Technics software
+9 VBC GMDSS
+10 VPM GMDSS
+11 BPP
+12 VBC 48V
+13 VVC2
+14 VBC 144V
+15 VBC2
+16 VBC 144V
+17 Lynx Shunt 1000A VE.Net
+256 BMV to NMEA2000 interface
+257 Skylla-i Control
+258 Hybrid Panel
+259 VE.Bus to NMEA2000 interface
+260 Skylla-i 24/100 (1+1)
+261 Skylla-i 24/80A (1+1)
+262 Skylla-i 24/100 (3)
+263 Skylla-i 24/80 (3)
+264 BlueSolar Charger MPPT 150/70
+320 Ion Control
+321 Lynx Shunt 1000A VE.Can
+322 Lynx Ion
+512 BMV-600S
+513 BMV-602S
+514 BMV-600HS
+515 BMV-700
+516 BMV-702
+517 BMV-700H
+529 BMV PCBA test firmware
+768 BlueSolar Charger MPPT 70/15
+4368 Remote panel
+4384 Remote panel 20MHz
+4385 Remote panel Dongle 20MHz
+4400 MK2 20Mhz
+4401 MK2 Dongle 20Mhz
+4402 VE.Bus Resetter (based on MK2) 20 Mhz
+4416 MK2 tachometer 20Mhz
+4421 BMS 20Mhz
+4432 Solar switch box
+4448 USB VEBus grabber
+4464 MK3
+5153 Phoenix Charger 12/100
+5154 Phoenix Charger 12/200
+5169 Phoenix Charger 24/50
+5170 Phoenix Charger 24/100
+5888 Phoenix Multi 12V full power
+5889 Phoenix Multi 12V half power
+5890 Phoenix MultiPlus 12V full power
+5891 MultiCompact 12V low power
+5892 MultiCompact 12V medium power
+5893 MultiCompact 12V high power
+5894 MultiCompactPlus 12V high power
+5895 MultiCompactPlus 12V medium power
+5904 Phoenix Multi 24V full power
+5905 Phoenix Multi 24V half power
+5906 Phoenix MultiPlus 24V full power
+5907 MultiCompact 24V low power
+5908 MultiCompact 24V medium power
+5909 MultiCompact 24V high power
+5910 MultiCompactPlus 24V high power
+5911 MultiCompactPlus 24V medium power
+5936 Phoenix Multi 120 12V full power
+5937 Phoenix Multi 120 12V half power
+5938 Phoenix MultiPlus 120 12V full power
+5952 Phoenix Multi 120 24V full power
+5953 Phoenix Multi 120 24V half power
+5954 Phoenix MultiPlus 120 24V full power
+5968 Phoenix Multi 48V full power
+5969 Phoenix Multi 48V half power
+5970 Phoenix MultiPlus 48V full power
+6144 Phoenix Multi 12V full power
+6145 Phoenix Multi 12V half power
+6146 Phoenix MultiPlus 12V full power
+6147 MultiCompact 12V low power
+6148 MultiCompact 12V medium power
+6149 MultiCompact 12V high power
+6150 MultiCompactPlus 12V high power
+6151 MultiCompactPlus 12V medium power
+6152 Phoenix MultiPlus 12V/2000
+6153 Phoenix MultiPlus 12V/3000
+6160 Phoenix Multi 24V full power
+6161 Phoenix Multi 24V half power
+6162 Phoenix MultiPlus 24V full power
+6163 MultiCompact 24V low power
+6164 MultiCompact 24V medium power
+6165 MultiCompact 24V high power
+6166 MultiCompactPlus 24V high power
+6167 MultiCompactPlus 24V medium power
+6168 Phoenix MultiPlus 24V/2000
+6192 Phoenix Multi 120 12V full power
+6193 Phoenix Multi 120 12V half power
+6194 Phoenix MultiPlus 120 12V full power
+6198 MultiCompactPlus 120 12V high power
+6201 Phoenix MultiPlus 120 12V/3000
+6208 Phoenix Multi 120 24V full power
+6209 Phoenix Multi 120 24V half power
+6210 Phoenix MultiPlus 120 24V full power
+6214 MultiCompactPlus 120 24V high power
+6224 Phoenix Multi 48V full power
+6225 Phoenix Multi 48V half power
+6226 Phoenix MultiPlus 48V full power
+6230 MultiCompactPlus 48V high power
+6242 Phoenix MultiPlus 120 48V full power
+6257 MultiCompactPlus 12V 2K
+6258 MultiCompactPlus 24V 2K
+6400 MultiPlus 12/3000/120-50
+6401 MultiPlus 12/3000/120-30
+6402 Phoenix MultiPlus 12V full power
+6403 Phoenix Multi Compact 12/800/35-16
+6406 MultiPlus Compact 12/1600/70-16
+6407 MultiPlus Compact 12/1200/50-16
+6408 MultiPlus Compact 12/2000/80-30
+6409 MultiPlus 12/3000/120-16
+6416 MultiPlus 24/3000/70-50
+6417 MultiPlus 24/3000/70-30
+6418 MultiPlus 24/3000/70-16
+6419 Phoenix Multi Compact 24/800/16-16
+6422 MultiPlus Compact 24/1600/40-16
+6423 MultiPlus Compact 24/1200/25-16
+6424 MultiPlus Compact 24/2000/50-30
+6432 MultiPlus 48/3000/35-50
+6433 MultiPlus 48/3000/35-30
+6434 MultiPlus 48/3000/35-16
+6448 Quattro 12/5000/200-2x30
+6449 Quattro 12/3000/120-50/30
+6450 Quattro 12/5000/200-50/30
+6451 Quattro 12/5000/220-2x75
+6464 Quattro 24/5000/120-2x30
+6465 Quattro 24/3000/70-50/30
+6466 Quattro 24/5000/120-50/30
+6467 Quattro 24/8000/200-2x100
+6472 Quattro 24/5000/120-2x100
+6473 MultiPlus 24/5000/120-50
+6480 Quattro 48/5000/70-2x30
+6482 Quattro 48/5000/70-50/30
+6483 Quattro 48/10000/140-2x100
+6484 Quattro 48/8000/110-2x100
+6488 Quattro 48/5000/70-2x100
+6489 MultiPlus 48/5000/70-50
+8194 MultiPlus 12/3000/120-50 120V
+8200 MultiPlus Compact 12/2000/80-50 120V
+8201 Phoenix MultiPlus 120 12V/3000
+8210 MultiPlus 24/3000/70-50 120V
+8216 MultiPlus Compact 24/2000/50-50 120V
+8226 Phoenix MultiPlus 120 48V/3000
+8264 Quattro 24/5000/120-2x100 120V
+8273 Quattro 48/3000/35-2x50 120V
+8275 Quattro 48/5000/70-2x100 120V
+8281 Phoenix MultiPlus 120 48V/5000
+8288 Phoenix 12/3000/120-50-120/240V
+8290 MultiPlus Compact 12/2000/80-50(30)-120/240V
+8305 Quattro 24/5000/120-2x60-120/240V
+8306 MultiPlus Compact 24/2000/50-50(30)-120/240V
+8320 Phoenix MultiPlus 120/240 48V/3000 with 50A AC relais
+8449 Phoenix HF
+9219 Phoenix 12/800
+9220 Phoenix 12/1200
+9235 Phoenix 24/800
+9236 Phoenix 24/1200
+9251 Phoenix 48/800
+9252 Phoenix 48/1200
+9299 Phoenix 12/800 120V
+9300 Phoenix 12/1200 120V
+9315 Phoenix 24/800 120V
+9316 Phoenix 24/1200 120V
+9331 Phoenix 48/800 120V
+9332 Phoenix 48/1200 120V
+9728 MultiPlus 12/3000/120-50
+9731 MultiPlus Compact 12/800/35-16
+9733 MultiPlus-II 12/3000/120-32
+9734 MultiPlus Compact 12/1600/70-16
+9735 MultiPlus Compact 12/1200/50-16
+9736 MultiPlus Compact 12/2000/80-30
+9737 MultiPlus 12/3000/120-16
+9744 MultiPlus 24/3000/70-50
+9745 MultiPlus-II 24/3000/70-32
+9746 MultiPlus 24/3000/70-16
+9747 MultiPlus Compact 24/800/16-16
+9748 MultiPlus 24/5000/120-100
+9749 MultiPlus-II 24/5000/120-50
+9750 MultiPlus Compact 24/1600/40-16
+9751 MultiPlus Compact 24/1200/25-16
+9752 MultiPlus Compact 24/2000/50-30
+9753 MultiPlus-II 48/15000/200-100
+9760 MultiPlus 48/3000/35-50
+9761 MultiPlus-II 48/8000/110-100
+9762 MultiPlus 48/3000/35-16
+9763 MultiPlus-II 48/5000/70-50
+9764 MultiPlus 48/5000/70-100
+9765 MultiPlus-II 48/3000/35-32
+9766 MultiPlus-II 48/5000/70-50
+9767 MultiPlus-II 48/10000/140-100/100
+9768 MultiPlus-II 48/3000/35-32
+9769 MultiPlus-II 48/3000/35-32
+9777 Quattro 12/3000/120-50/30
+9778 Quattro-II 12/5000/200-2x50
+9779 Quattro 12/5000/220-2x75
+9780 Quattro 12/3000/120-2x50
+9793 Quattro 24/3000/70-50/30
+9794 Quattro 24/5000/120-50/30
+9795 Quattro 24/8000/200-2x100
+9796 Quattro 24/3000/70-2x50
+9797 Quattro-II 24/5000/120-2x50
+9800 Quattro 24/5000/120-2x100
+9801 MultiPlus 24/5000/120-50
+9809 Quattro-II 48/5000/70-2x50
+9810 Quattro 48/5000/70-50/30
+9811 Quattro 48/10000/140-2x100
+9812 Quattro 48/8000/110-2x100
+9813 Quattro 48/8000/110-2x100
+9814 Quattro 48/15000/200-2x100
+9815 Quattro 48/5000/70-2x100-S
+9816 Quattro 48/5000/70-2x100
+9817 MultiPlus 48/5000/70-50
+9824 MultiPlus 12/500/20-16
+9825 MultiPlus 12/800/35-16
+9826 MultiPlus 12/1200/50-16
+9827 MultiPlus 12/1600/70-16
+9828 MultiPlus 12/2000/80-32
+9829 MultiPlus 24/500/10-16
+9830 MultiPlus 24/800/16-16
+9831 MultiPlus 24/1200/25-16
+9832 MultiPlus 24/1600/40-16
+9833 MultiPlus 24/2000/50-32
+9840 MultiPlus 48/500/6-16
+9841 MultiPlus 48/800/9-16
+9842 MultiPlus 48/1200/13-16
+9843 MultiPlus 48/1600/20-16
+9844 MultiPlus 48/2000/25-32
+9856 MultiGrid 12/3000/120-50
+9861 MultiGrid 24/3000/70-50
+9872 MultiGrid 48/3000/35-50
+9986 MultiPlus 12/3000/120-50 120V
+9989 MultiPlus-II 12/3000/120-50 120V
+9992 MultiPlus Compact 12/2000/80-50 120V
+10001 MultiPlus-II 24/3000/70-50 120V
+10002 MultiPlus 24/3000/70-50 120V
+10008 MultiPlus Compact 24/2000/50-50 120V
+10025 MultiPlus-II 48/3000/35-50 120V
+10035 Quattro 12/5000/220-2x100 120V
+10056 Quattro 24/5000/120-2x100 120V
+10065 Quattro 48/3000/35-2x50 120V
+10067 Quattro 48/5000/70-2x100 120V
+10068 Quattro 48/10000/140-2x100 120V
+10084 MultiPlus 12/2000/80-50 120V
+10089 MultiPlus 24/2000/50-50 120V
+10100 MultiPlus 48/2000/25-50 120V
+10101 MultiPlus-II 24/3000/70-50 2x120V
+10112 MultiPlus-II 12/3000/120-50 2x120V
+10113 Quattro-II 12/3000/120-2x50 2x120V
+40960 Skylla-IP44/IP65 battery charger
+40961 Skylla-IP65 12V/70A (1+1)
+40962 Skylla-IP65 12V/70A (3)
+40963 Skylla-IP44 12V/60A (1+1)
+40964 Skylla-IP44 12V/60A (3)
+40965 Skylla-IP65 24V/35A (1+1)
+40966 Skylla-IP65 24V/35A (3)
+40967 Skylla-IP44 24V/30A (1+1)
+40968 Skylla-IP44 24V/30A (3)
+40976 Skylla-S battery charger
+40977 Skylla-S 12V/100A (1+1)
+40978 Skylla-S 12V/100A (3)
+40979 Skylla-S 24V/100A (1+1)
+40980 Skylla-S 24V/100A (3)
+40981 Skylla-S 24V/50A (1+1)
+40982 Skylla-S 24V/50A (3)
+41024 BlueSolar Charger MPPT 75/50
+41025 BlueSolar Charger MPPT 150/35 rev1
+41026 BlueSolar Charger MPPT 75/15
+41027 BlueSolar Charger MPPT 100/15
+41028 BlueSolar Charger MPPT 100/30 rev1
+41029 BlueSolar Charger MPPT 100/50 rev1
+41030 BlueSolar Charger MPPT 150/70
+41031 BlueSolar Charger MPPT 150/100
+41032 BlueSolar Charger MPPT 75/50 rev2
+41033 BlueSolar Charger MPPT 100/50 rev2
+41034 BlueSolar Charger MPPT 100/30 rev2
+41035 BlueSolar Charger MPPT 150/35 rev2
+41036 BlueSolar Charger MPPT 75/10
+41037 BlueSolar Charger MPPT 150/45
+41038 BlueSolar Charger MPPT 150/60
+41039 BlueSolar Charger MPPT 150/85
+41040 SmartSolar Charger MPPT 250/100
+41041 SmartSolar Charger MPPT 150/100
+41042 SmartSolar Charger MPPT 150/85
+41043 SmartSolar Charger MPPT 75/15
+41044 SmartSolar Charger MPPT 75/10
+41045 SmartSolar Charger MPPT 100/15
+41046 SmartSolar Charger MPPT 100/30
+41047 SmartSolar Charger MPPT 100/50
+41048 SmartSolar Charger MPPT 150/35
+41049 SmartSolar Charger MPPT 150/100 rev2
+41050 SmartSolar Charger MPPT 150/85 rev2
+41051 SmartSolar Charger MPPT 250/70
+41052 SmartSolar Charger MPPT 250/85
+41053 SmartSolar Charger MPPT 250/60
+41054 SmartSolar Charger MPPT 250/60
+41055 SmartSolar Charger MPPT 100/20
+41056 SmartSolar Charger MPPT 100/20 48V
+41057 SmartSolar Charger MPPT 150/45
+41058 SmartSolar Charger MPPT 150/60
+41059 SmartSolar Charger MPPT 150/70
+41060 SmartSolar Charger MPPT 250/85 rev2
+41061 SmartSolar Charger MPPT 250/100 rev2
+41062 BlueSolar Charger MPPT 100/20
+41063 BlueSolar Charger MPPT 100/20 48V
+41064 SmartSolar Charger MPPT 250/60 rev2
+41065 SmartSolar Charger MPPT 250/70 rev2
+41066 SmartSolar Charger MPPT 150/45 rev2
+41067 SmartSolar Charger MPPT 150/60 rev2
+41068 SmartSolar Charger MPPT 150/70 rev2
+41069 SmartSolar Charger MPPT 150/85 rev3
+41070 SmartSolar Charger MPPT 150/100 rev3
+41071 BlueSolar Charger MPPT 150/45 rev2
+41072 BlueSolar Charger MPPT 150/60 rev2
+41073 BlueSolar Charger MPPT 150/70 rev2
+41074 BlueSolar Charger MPPT 150/45 rev3
+41075 SmartSolar Charger MPPT 150/45 rev3
+41076 SmartSolar Charger MPPT 75/10 rev2
+41077 SmartSolar Charger MPPT 75/15 rev2
+41078 BlueSolar Charger MPPT 100/30 rev3
+41079 BlueSolar Charger MPPT 100/50 rev3
+41080 BlueSolar Charger MPPT 150/35 rev3
+41081 BlueSolar Charger MPPT 75/10 rev2
+41082 BlueSolar Charger MPPT 75/15 rev2
+41083 BlueSolar Charger MPPT 100/15 rev2
+41084 BlueSolar Charger MPPT 75/10 rev3
+41085 BlueSolar Charger MPPT 75/15 rev3
+41086 SmartSolar Charger MPPT 100/30 12V
+41153 Lithium Battery Balancer 12V/3.5A
+41154 Lithium Battery Balancer 12V/8A
+41155 Lithium Battery Balancer 24V/3.5A
+41156 Lithium Battery Balancer 12V/2A
+41184 Smart Lithium Battery 12.8V/90Ah
+41185 Smart Lithium Battery 12.8V/60Ah
+41186 Smart Lithium Battery 12.8V/160Ah
+41187 Smart Lithium Battery 12.8V/200Ah
+41188 Smart Lithium Battery 12.8V/300Ah
+41189 Smart Lithium Battery 12.8V/100Ah
+41190 Smart Lithium Battery 12.8V/200Ah
+41191 Smart Lithium Battery 12.8V/300Ah
+41192 Smart Lithium Battery 12.8V/100Ah
+41193 Smart Lithium Battery 12.8V/150Ah
+41194 Smart Lithium Battery 25.6V/200Ah
+41195 Smart Lithium Battery 12.8V/200Ah
+41196 Smart Lithium Battery 12.8V/160Ah
+41197 Smart Lithium Battery 12.8V/50Ah
+41198 Smart Lithium Battery 25.6V/200Ah
+41199 Smart Lithium Battery 25.6V/100Ah
+41200 Smart Lithium Battery 12.8V/330Ah
+41201 Smart Lithium Battery 25.6V/330Ah
+41202 Smart Lithium Battery 12.8V/300Ah
+41216 BlueSolar Remote Panel
+41217 BlueSolar Charger MPPT 150/85
+41218 SmartSolar MPPT VE.Can 150/70
+41219 SmartSolar MPPT VE.Can 150/45
+41220 SmartSolar MPPT VE.Can 150/60
+41221 SmartSolar MPPT VE.Can 150/85
+41222 SmartSolar MPPT VE.Can 150/100
+41223 SmartSolar MPPT VE.Can 250/45
+41224 SmartSolar MPPT VE.Can 250/60
+41225 SmartSolar MPPT VE.Can 250/70
+41226 SmartSolar MPPT VE.Can 250/85
+41227 SmartSolar MPPT VE.Can 250/100
+41228 SmartSolar MPPT VE.Can 150/70 rev2
+41229 SmartSolar MPPT VE.Can 150/85 rev2
+41230 SmartSolar MPPT VE.Can 150/100 rev2
+41231 BlueSolar MPPT VE.Can 150/100
+41232 SmartSolar MPPT RS 450/100
+41233 SmartSolar MPPT RS 450/200
+41234 BlueSolar MPPT VE.Can 250/70
+41235 BlueSolar MPPT VE.Can 250/100
+41236 SmartSolar MPPT VE.Can 250/70 rev2
+41237 SmartSolar MPPT VE.Can 250/100 rev2
+41238 SmartSolar MPPT VE.Can 250/85 rev2
+41239 BlueSolar MPPT VE.Can 150/100 rev2
+41248 VE.Bus to NMEA2000 interface (rev2)
+41249 VE.Direct to CAN interface
+41264 Lynx Ion + Shunt
+41265 Lynx Smart Shunt 1000A VE.Can
+41280 PV Inverter (QWACS)
+41281 PV Inverter (AC Current Sensor)
+41282 Fronius solar inverters
+41283 SMA solar inverters
+41284 SunSpec solar inverters
+41285 ABB/Fimer solar inverters
+41312 Tank sensor
+41313 Generic Tank Input
+41314 Generic Temperature Input
+41315 NMEA-0183 GPS
+41316 NMEA 2000 GPS
+41317 Generic pulse meter
+41318 Generic digital input
+41328 Mppt control
+41329 Mppt control PCBA test firmware
+41344 Peak Power Pack 12V 8Ah
+41345 Peak Power Pack PCBA test firmware
+41346 VE.Direct Bluetooth Smart Dongle
+41347 Bootloader for softdevice v7
+41348 Virtual id for v1 legacy dongle
+41349 Peak Power Pack 12V 20Ah
+41350 Peak Power Pack 12V 30Ah
+41351 Peak Power Pack 12V 40Ah
+41352 VE.Direct Bluetooth Smart Dongle (Rev2)
+41353 VE.Direct Bluetooth Smart Dongle (Rev3)
+41360 SmartSolar Bluetooth Interface
+41361 SmartSolar Bluetooth Interface (Rev2)
+41362 BMV-7xx Smart Bluetooth Interface
+41363 Lynx Ion BMS Bluetooth Interface
+41364 Phoenix Inverter Smart Bluetooth Interface
+41365 VE.Can SmartSolar Bluetooth Interface
+41366 SmartShunt Bluetooth Interface
+41367 SmartSolar Bluetooth Interface (Rev3)
+41368 BMV-7xx Smart Bluetooth Interface (Rev2)
+41369 Lynx Ion BMS Bluetooth Interface (Rev2)
+41370 Phoenix Inverter Smart Bluetooth Interface (Rev2)
+41371 VE.Can SmartSolar Bluetooth Interface (Rev2)
+41372 SmartShunt Bluetooth Interface (Rev2)
+41373 SmartShunt Bluetooth Interface (Rev2)
+41374 Sun Inverter Bluetooth Interface
+41375 All-In-1 Bluetooth Interface
+41392 Smart Energy Meter
+41393 VE.Can Energy Meter
+41472 Phoenix Inverter
+41473 Phoenix Inverter 12V 250VA 230V
+41474 Phoenix Inverter 24V 250VA 230V
+41476 Phoenix Inverter 48V 250VA 230V
+41489 Phoenix Inverter 12V 375VA 230V
+41490 Phoenix Inverter 24V 375VA 230V
+41492 Phoenix Inverter 48V 375VA 230V
+41505 Phoenix Inverter 12V 500VA 230V
+41506 Phoenix Inverter 24V 500VA 230V
+41508 Phoenix Inverter 48V 500VA 230V
+41521 Phoenix Inverter 12V 250VA 230V
+41522 Phoenix Inverter 24V 250VA 230V
+41524 Phoenix Inverter 48V 250VA 230V
+41525 Phoenix Sun Inverter 12V 250VA 230V
+41526 Phoenix Sun Inverter 24V 250VA 230V
+41527 Phoenix Sun Inverter 48V 250VA 230V
+41529 Phoenix Inverter 12V 250VA 120V
+41530 Phoenix Inverter 24V 250VA 120V
+41532 Phoenix Inverter 48V 250VA 120V
+41537 Phoenix Inverter 12V 375VA 230V
+41538 Phoenix Inverter 24V 375VA 230V
+41540 Phoenix Inverter 48V 375VA 230V
+41545 Phoenix Inverter 12V 375VA 120V
+41546 Phoenix Inverter 24V 375VA 120V
+41548 Phoenix Inverter 48V 375VA 120V
+41553 Phoenix Inverter 12V 500VA 230V
+41554 Phoenix Inverter 24V 500VA 230V
+41556 Phoenix Inverter 48V 500VA 230V
+41561 Phoenix Inverter 12V 500VA 120V
+41562 Phoenix Inverter 24V 500VA 120V
+41564 Phoenix Inverter 48V 500VA 120V
+41569 Phoenix Inverter 12V 800VA 230V
+41570 Phoenix Inverter 24V 800VA 230V
+41572 Phoenix Inverter 48V 800VA 230V
+41577 Phoenix Inverter 12V 800VA 120V
+41578 Phoenix Inverter 24V 800VA 120V
+41580 Phoenix Inverter 48V 800VA 120V
+41585 Phoenix Inverter 12V 1200VA 230V
+41586 Phoenix Inverter 24V 1200VA 230V
+41588 Phoenix Inverter 48V 1200VA 230V
+41593 Phoenix Inverter 12V 1200VA 120V
+41594 Phoenix Inverter 24V 1200VA 120V
+41596 Phoenix Inverter 48V 1200VA 120V
+41601 Smart Phoenix Inverter 12V 2000VA 230V
+41602 Smart Phoenix Inverter 24V 2000VA 230V
+41604 Smart Phoenix Inverter 48V 2000VA 230V
+41609 Smart Phoenix Inverter 12V 2000VA 120V
+41610 Smart Phoenix Inverter 24V 2000VA 120V
+41612 Smart Phoenix Inverter 48V 2000VA 120V
+41617 Smart Phoenix Inverter 12V 2000VA 230V
+41618 Smart Phoenix Inverter 24V 2000VA 230V
+41620 Smart Phoenix Inverter 48V 2000VA 230V
+41625 Smart Phoenix Inverter 12V 2000VA 120V
+41626 Smart Phoenix Inverter 24V 2000VA 120V
+41628 Smart Phoenix Inverter 48V 2000VA 120V
+41633 Smart Phoenix Inverter 12V 3000VA 230V
+41634 Smart Phoenix Inverter 24V 3000VA 230V
+41636 Smart Phoenix Inverter 48V 3000VA 230V
+41641 Smart Phoenix Inverter 12V 3000VA 120V
+41642 Smart Phoenix Inverter 24V 3000VA 120V
+41644 Smart Phoenix Inverter 48V 3000VA 120V
+41650 Smart Phoenix Inverter 24V 5000VA 230V
+41652 Smart Phoenix Inverter 48V 5000VA 230V
+41658 Smart Phoenix Inverter 24V 5000VA 120V
+41660 Smart Phoenix Inverter 48V 5000VA 120V
+41697 Phoenix Inverter 12V 800VA 230V
+41698 Phoenix Inverter 24V 800VA 230V
+41700 Phoenix Inverter 48V 800VA 230V
+41705 Phoenix Inverter 12V 800VA 120V
+41706 Phoenix Inverter 24V 800VA 120V
+41708 Phoenix Inverter 48V 800VA 120V
+41713 Phoenix Inverter 12V 1200VA 230V
+41714 Phoenix Inverter 24V 1200VA 230V
+41716 Phoenix Inverter 48V 1200VA 230V
+41721 Phoenix Inverter 12V 1200VA 120V
+41722 Phoenix Inverter 24V 1200VA 120V
+41724 Phoenix Inverter 48V 1200VA 120V
+41728 Blue Smart Charger - Generic
+41729 Blue Smart IP65 Charger 12|10
+41730 Blue Smart IP65 Charger 12|15
+41731 Blue Smart IP65 Charger 24|8
+41732 Blue Smart IP65 Charger 12|5
+41733 Blue Smart IP65 Charger 12|7
+41734 Blue Smart IP65 Charger 24|5
+41735 Blue Smart IP65 Charger 12|4
+41736 Blue Smart IP65s Charger 12|4
+41737 Blue Smart IP65s Charger 12|5
+41738 Blue Smart IP65 Charger 12|25
+41739 Blue Smart IP65 Charger 24|13
+41740 Blue Smart IP65 Charger 6V/12V-1.1A
+41741 Blue Smart IP65s Charger 12/4
+41742 Blue Smart IP65s Charger 12/5
+41743 Blue Smart IP65 Charger 12/7
+41744 Blue Smart IP67 Charger 12|7
+41745 Blue Smart IP67 Charger 12|13
+41746 Blue Smart IP67 Charger 24|5
+41747 Blue Smart IP67 Charger 12|17
+41748 Blue Smart IP67 Charger 12|25
+41749 Blue Smart IP67 Charger 24|8
+41750 Blue Smart IP67 Charger 24|12
+41751 Blue Smart IP67 Charger 12/7
+41752 Blue Smart IP67 Charger 12/13
+41753 Blue Smart IP67 Charger 24/5
+41754 Blue Smart IP67 Charger 12/17
+41755 Blue Smart IP67 Charger 12/25
+41756 Blue Smart IP67 Charger 24/8
+41757 Blue Smart IP67 Charger 24/12
+41760 Blue Smart IP22 Charger 12|15 (1)
+41761 Blue Smart IP22 Charger 12|15 (3)
+41762 Blue Smart IP22 Charger 12|20 (1)
+41763 Blue Smart IP22 Charger 12|20 (3)
+41764 Blue Smart IP22 Charger 12|30 (1)
+41765 Blue Smart IP22 Charger 12|30 (3)
+41766 Blue Smart IP22 Charger 24|8 (1)
+41767 Blue Smart IP22 Charger 24|8 (3)
+41768 Blue Smart IP22 Charger 24|12 (1)
+41769 Blue Smart IP22 Charger 24|12 (3)
+41770 Blue Smart IP22 Charger 24|16 (1)
+41771 Blue Smart IP22 Charger 24|16 (3)
+41772 Blue Smart IP22 Charger 12/15 (1)
+41773 Blue Smart IP22 Charger 12/15 (3)
+41774 Blue Smart IP22 Charger 12/20 (1)
+41775 Blue Smart IP22 Charger 12/20 (3)
+41776 Blue Smart IP22 Charger 12/30 (1)
+41777 Blue Smart IP22 Charger 12/30 (3)
+41778 Blue Smart IP22 Charger 24/8 (1)
+41779 Blue Smart IP22 Charger 24/8 (3)
+41780 Blue Smart IP22 Charger 24/12 (1)
+41781 Blue Smart IP22 Charger 24/12 (3)
+41782 Blue Smart IP22 Charger 24/16 (1)
+41783 Blue Smart IP22 Charger 24/16 (3)
+41784 Blue Smart IP65 Charger 12/10
+41785 Blue Smart IP65 Charger 12/15
+41786 Blue Smart IP65 Charger 24/5
+41787 Blue Smart IP65 Charger 24/8
+41788 Blue Smart IP65 Charger 12/5
+41792 Phoenix Smart IP43 Charger 12|50 (1+1) 230V
+41793 Phoenix Smart IP43 Charger 12|50 (3) 230V
+41794 Phoenix Smart IP43 Charger 24|25 (1+1) 230V
+41795 Phoenix Smart IP43 Charger 24|25 (3) 230V
+41796 Phoenix Smart IP43 Charger 12|30 (1+1) 230V
+41797 Phoenix Smart IP43 Charger 12|30 (3) 230V
+41798 Phoenix Smart IP43 Charger 24|16 (1+1) 230V
+41799 Phoenix Smart IP43 Charger 24|16 (3) 230V
+41808 Phoenix Smart IP43 Charger 12|50 (1+1) 120-240V
+41809 Phoenix Smart IP43 Charger 12|50 (3) 120-240V
+41810 Phoenix Smart IP43 Charger 24|25 (1+1) 120-240V
+41811 Phoenix Smart IP43 Charger 24|25 (3) 120-240V
+41812 Phoenix Smart IP43 Charger 12|30 (1+1) 120-240V
+41813 Phoenix Smart IP43 Charger 12|30 (3) 120-240V
+41814 Phoenix Smart IP43 Charger 24|16 (1+1) 120-240V
+41815 Phoenix Smart IP43 Charger 24|16 (3) 120-240V
+41824 IMPULSE-II 24/6 Smart IP44
+41825 IMPULSE-II 24/8 Smart IP44
+41826 IMPULSE-II 24/6 Smart IP65
+41827 IMPULSE-II 24/8 Smart IP65
+41828 IMPULSE-II 24/6 Smart IP44
+41829 IMPULSE-II 24/8 Smart IP44
+41830 IMPULSE-II 24/12 Smart IP65
+41831 IMPULSE-II 24/11 Smart IP44
+41832 IMPULSE-II 24/8 Smart IP44
+41833 IMPULSE-II 24/6 Smart IP44
+41834 IMPULSE-II 24/8 Smart IP65
+41835 IMPULSE-II 24/6 Smart IP65
+41853 Vector 12/20 Smart
+41854 IMPULSE-II L 12/20 Smart
+41855 IMPULSE-II L 12/20 Smart
+41856 BMV-710 Smart
+41857 BMV-712 Smart
+41858 BMV-710H Smart
+41859 BMV-712 Smart
+41865 SmartShunt 500A/50mV
+41866 SmartShunt 1000A/50mV
+41867 SmartShunt 2000A/50mV
+41868 SmartShunt IP67 500A/50mV
+41869 SmartShunt IP67 1000A/50mV
+41870 SmartShunt IP67 2000A/50mV
+41872 Lynx Ion BMS General
+41873 Lynx Ion BMS 150A
+41874 Lynx Ion BMS 400A
+41875 Lynx Ion BMS 600A
+41876 Lynx Ion BMS 1000A
+41888 VE.Bus smart dongle
+41892 Smart VT sensor
+41893 Smart VT sensor (Rev2)
+41904 Smart BatteryProtect 12/24V-65A
+41905 Smart BatteryProtect 12/24V-100A
+41906 Smart BatteryProtect 12/24V-220A
+41907 Smart BatteryProtect 48V-100A
+41920 Orion Smart 12V/12V-18A DC-DC Converter
+41921 Orion Smart 12V/24V-10A DC-DC Converter
+41922 Orion Smart 24V/12V-20A DC-DC Converter
+41923 Orion Smart 24V/24V-12A DC-DC Converter
+41924 Orion Smart 24V/48V-6A DC-DC Converter
+41925 Orion Smart 48V/12V-20A DC-DC Converter
+41926 Orion Smart 48V/24V-12A DC-DC Converter
+41927 Orion Smart 48V/48V-6A DC-DC Converter
+41928 Orion Smart 12V/12V-30A DC-DC Converter
+41929 Orion Smart 12V/24V-15A DC-DC Converter
+41930 Orion Smart 24V/12V-30A DC-DC Converter
+41931 Orion Smart 24V/24V-17A DC-DC Converter
+41932 Orion Smart 24V/48V-8.5A DC-DC Converter
+41933 Orion Smart 48V/12V-30A DC-DC Converter
+41934 Orion Smart 48V/24V-16A DC-DC Converter
+41935 Orion Smart 48V/48V-8A DC-DC Converter
+41936 Orion Smart 12V/12V-30A Buck-Boost Converter
+41937 Orion Smart 12V/24V-15A Buck-Boost Converter
+41938 Orion Smart Orion 24V/12V-30A Buck-Boost Converter
+41939 Orion Smart Orion 24V/24V-17A Buck-Boost Converter
+41952 Smart BMS CL 12-100
+41957 Lynx Smart BMS 500
+41958 Lynx Smart BMS 1000
+41960 Smart BMS 12-200
+41964 smallBMS
+41968 Smart Buckboost 12V/12V-50A non-iso DC-DC charger
+41984 MultiC - Generic
+41985 Inverter RS Solar 48V/6000VA/80A
+41986 Inverter RS 48V/6000VA
+42049 Multi RS Solar 48V/6000VA/100A
+42050 Multi RS Solar 48V/6000VA/100A
+42051 Multi RS Solar 48V/6000VA/100A
+42052 Multi RS Solar 48V/6000VA/100A
+42112 Multi 15kVA 3phase
+42176 Transfer Switch - Generic id
+42177 Transfer Switch 3 Phase 2 in 1 out 80A
+42241 MultiPlus-X Smart 12V/3000VA/120A
+45056 Valence XP Battery
+45057 Valence BMS
+45058 Carlo Gavazzi EM24 Energy Meter
+45059 Redflow ZBM 2 Battery
+45060 LG resu battery
+45061 BMZ battery
+45062 Carlo Gavazzi virtual PV Inverter (on EM24)
+45063 CAN-bus BMS battery
+45064 Murata battery
+45065 Pylontech battery
+45066 BYD B-Box Pro battery
+45067 PureDrive battery
+45068 Carlo Gavazzi ET 112 Energy Meter
+45069 Carlo Gavazzi ET 340 Energy Meter
+45070 ZCell BMS
+45071 Energy Tube EMSC2 battery
+45072 Mercedes Benz Energy battery
+45073 Carlo Gavazzi virtual PV Inverter (on ET340)
+45074 FIAMM SoNick 48TL battery
+45075 SSS DC Energy Meter/Switch
+45076 Freedom WON battery
+45077 BYD B-Box L battery
+45078 Discover AES battery
+45079 Carlo Gavazzi EM24 Ethernet Energy Meter
+45080 Smappee Power Box
+45081 BYD Premium LV battery
+45088 BlueNova battery
+45089 BSLBATT battery
+45090 REC-BMS battery
+45091 Eastron SDM630 Energy Meter
+45092 Freedom WON eTower battery
+45093 Dyness battery
+45094 Carlo Gavazzi EM540 Energy Meter
+45095 Carlo Gavazzi virtual PV Inverter (on EM540)
+45096 Cegasa battery
+45097 Pylontech Pelio-L battery
+45104 IMT Si-RS485 Series Solar Irradiance Sensor
+45105 Carlo Gavazzi EM300 Spec 27 Energy Meter
+45106 Carlo Gavazzi virtual PV Inverter (on EM300 Spec 27)
+45107 ABB B-Series Energy Meter
+45108 Shelly EM/3EM Energy Meter
+45120 Fischer Panda Genset
+45121 WATT Imperium Fuel Cell 3.0
+45122 Bornay Windplus
+45123 WATT Imperium Fuel Cell 4.0
+45136 123 SmartBMS
+45137 Hubble battery
+45152 Oceanvolt Display 2
+45153 Oceanvolt ServoProp
+45168 Volturnus Wind Turbine Voltage Limiter
+45169 EConnect Distribution Box
+45184 Wakespeed WS500 Alternator Regulator
+45185 Wakespeed WS3000 DCDC EMS
+45248 MG BMS 24-96V General
+45249 MG BMS 24-48V/150A
+45250 MG BMS 24-48V/400A
+45251 MG BMS 24-48V/600A
+45252 MG BMS 24-48V/1000A
+45253 MG BMS 72V/400A
+45254 MG BMS 96V/600A
+45255 MG BMS 72-96V/500A
+45264 MG BMS 12V General
+45265 MG BMS 12V/150
+45266 MG BMS 12V/400A
+45267 MG BMS 12V/600A
+45268 MG BMS 12V/1000A
+45272 MG BMS 48-900V General
+45273 MG BMS 48-900V/300A
+45274 MG BMS 48-900V/500A
+45280 MG SmartLink MX
+45281 MG SmartLink Connect
+45282 MG SmartLink PLC
+49152 VGR, VGR2 or VER
+49153 Color Control
+49154 Venus GX
+49155 Generic Venus Device
+49156 VE.Direct LoRaWAN
+49157 VE.Direct LoRaWAN Smart
+49158 Octo GX
+49159 EasySolar-II
+49160 MultiPlus-II
+49161 Maxi GX
+49162 Cerbo GX
+49163 EasySolar-II
+49164 MultiPlus-II
+49165 Maxi GX
+49166 EasySolar-II
+49167 MultiPlus-II
+49168 Maxi GX
+49169 SHS400
+49170 Cerbo GX
+49171 Ekrano GX
+49172 Cerbo-S GX
+49184 VE.Direct LoRaWAN
+49185 Global Link 520
+49188 EV Charge Station 32A
+49189 EV Charge Station 32A
+49190 EV Charge Station 32A NS
+49192 GX Tank 140
+49193 RuuviTag
+49194 Mopeka sensor
+49200 SmartShunt IP65 500A/50mV
+49201 SmartShunt IP65 1000A/50mV
+49202 SmartShunt IP65 2000A/50mV
+49203 All-In-1 Smart
+49204 BMV-800 Smart
+49205 SmartShunt IP65 500A/50mV
+49206 SmartShunt IP65 1000A/50mV
+49207 SmartShunt IP65 2000A/50mV
+57344 Generic example 0
+57345 Generic example 1
+57346 Generic example 2
+57347 Generic example 3
+57348 Generic example 4
+57349 Generic example 5
+57350 Generic example 6
+57351 Generic example 7
+57352 XUP example 0
+57353 XUP example 1
+57354 XUP example 2
+57355 XUP example 3
+57356 XUP example 4
+57357 XUP example 5
+57358 XUP example 6
+57359 XUP example 7
+57360 BUP example 0
+57361 BUP example 1
+57362 BUP example 2
+57363 BUP example 3
+57364 BUP example 4
+57365 BUP example 5
+57366 BUP example 6
+57367 BUP example 7
+57368 DUP example 0
+57369 DUP example 1
+57370 DUP example 2
+57371 DUP example 3
+57372 DUP example 4
+57373 DUP example 5
+57374 DUP example 6
+57375 DUP example 7
+65024 sw vedirect interface
+65025 sw ble interface
+65026 sw VE.Bus interface
+65027 sw mqtt interface
+65534 reserved
+65535 No product set

--- a/tests/test_dbus_service.py
+++ b/tests/test_dbus_service.py
@@ -520,16 +520,50 @@ class PowerLimitTest(unittest.TestCase):
     @patch('dbus_service.dbus')
     @patch('dbus_service.logging')
     @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
-    def test_refresh_limit_status_publishes_max_power(
+    def test_init_seeds_max_power_and_power_limit_from_opendtu(
             self, mock_get, mock_logging, mock_dbus, mock_config):
-        """_refresh_limit_status populates /Ac/MaxPower and /Ac/PowerLimit."""
+        """At init, /Ac/MaxPower and /Ac/PowerLimit are seeded via add_path(initial=...)
+           from /api/limit/status, so no post-register writes emit PropertiesChanged."""
+        DbusService._meter_data = None
+        service = DbusService("com.victronenergy.pvinverter", 0)
+        by_path = {c.args[0]: c.args[1] for c in service._dbusservice.add_path.call_args_list}
+        self.assertEqual(by_path["/Ac/MaxPower"], 2000)
+        # limit_relative=50 and max_power=2000 -> 1000W initial PowerLimit
+        self.assertEqual(by_path["/Ac/PowerLimit"], 1000.0)
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    def test_refresh_limit_status_skips_seed_when_already_seeded(
+            self, mock_get, mock_logging, mock_dbus, mock_config):
+        """Once init (or a prior fallback) has seeded the paths, _refresh_limit_status
+           must not re-write them — that would round-trip via onchangecallback and POST."""
         DbusService._meter_data = None
         service = self._make_service()
+        service._limit_seeded = True
+        service._refresh_limit_status()
+        self.assertIsNone(service._dbusservice["/Ac/MaxPower"])
+        self.assertIsNone(service._dbusservice["/Ac/PowerLimit"])
+        # limit_set_status=Ok -> RUNNING (7)
+        self.assertEqual(service._dbusservice["/StatusCode"], 7)
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    def test_refresh_limit_status_fallback_seeds_when_init_failed(
+            self, mock_get, mock_logging, mock_dbus, mock_config):
+        """If init's fetch failed, the first successful _refresh_limit_status seeds
+           /Ac/MaxPower and /Ac/PowerLimit and flips _limit_seeded so it fires once."""
+        DbusService._meter_data = None
+        service = self._make_service()
+        service._limit_seeded = False
         service._refresh_limit_status()
         self.assertEqual(service._dbusservice["/Ac/MaxPower"], 2000)
-        # limit_relative=50 and max_power=2000 -> 1000W initial PowerLimit
+        # limit_relative=50, max_power=2000 -> 1000W
         self.assertEqual(service._dbusservice["/Ac/PowerLimit"], 1000.0)
-        self.assertEqual(service._dbusservice["/StatusCode"], 7)
+        self.assertTrue(service._limit_seeded)
 
     @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
     @patch('dbus_service.dbus')

--- a/tests/test_dbus_service.py
+++ b/tests/test_dbus_service.py
@@ -418,8 +418,9 @@ class ReconnectLogicTest(unittest.TestCase):
         self.service.reset_statuscode_on_next_success = False
         self.service._refresh_data.side_effect = requests.exceptions.RequestException("Test exception")
         self.service.update()
-        # reset refresh_data to simulate a successful update
+        # reset refresh_data to simulate a successful update; inverter also reachable again
         self.service._refresh_data = MagicMock()
+        self.service.is_data_up2date = MagicMock(return_value=True)
         self.service.update()
         self.assertNotEqual(self.service._dbusservice['/StatusCode'], 10)
 
@@ -432,7 +433,6 @@ class ReconnectLogicTest(unittest.TestCase):
         self.service.is_data_up2date = MagicMock(return_value=True)
         self.service.update()
         self.service._refresh_data.assert_called_once()
-        self.service.is_data_up2date.assert_called_once()
         self.service.set_dbus_values.assert_called_once()
         self.service._update_index.assert_called_once()
         self.assertEqual(self.service.failed_update_count, 0)
@@ -452,7 +452,6 @@ class ReconnectLogicTest(unittest.TestCase):
         self.service._update_index = MagicMock()
         self.service.update()
         self.service._refresh_data.assert_called_once()
-        self.service.is_data_up2date.assert_called_once()
         self.service.set_dbus_values.assert_called_once()
         self.service._update_index.assert_called_once()
         self.assertEqual(self.service.failed_update_count, 0)
@@ -716,6 +715,47 @@ class PvInverterSchemaTest(unittest.TestCase):
         status_calls = [c for c in service._dbusservice.add_path.call_args_list
                         if c.args[0] == "/StatusCode"]
         self.assertEqual(status_calls[0].args[1], STATUSCODE_STARTUP)
+
+
+class OfflinePublishingTest(unittest.TestCase):
+    """Regression: at night (OpenDTU reachable=false) yield totals and StatusCode=ERROR
+    must still be written to DBus, not skipped."""
+
+    def setUp(self):
+        DbusService._meter_data = None
+
+    def tearDown(self):
+        DbusService._meter_data = None
+
+    def test_set_dbus_values_publishes_yield_and_error_when_offline(self):
+        from constants import STATUSCODE_ERROR
+        service = DbusService(servicename="testing", actual_inverter=0)
+        service.dtuvariant = "opendtu"
+        service._servicename = "com.victronenergy.pvinverter"
+        service.pvinverterphase = "L1"
+        service.useyieldday = False
+        service.dry_run = False
+        # Craft OpenDTU livedata with an unreachable, non-producing inverter that
+        # nevertheless still has a YieldTotal accumulated from earlier in the day.
+        service.set_test_data({
+            "inverters": [{
+                "serial": "114182000001",
+                "reachable": False,
+                "producing": False,
+                "AC": {"0": {"Power": {"v": 0}, "Voltage": {"v": 0}, "Current": {"v": 0},
+                             "YieldTotal": {"v": 12.345}}},
+                "DC": {"0": {"Voltage": {"v": 0}}},
+            }],
+        })
+        service._dbusservice = {p: None for p in [
+            "/Ac/Power", "/Ac/L1/Voltage", "/Ac/L1/Current", "/Ac/L1/Power",
+            "/Ac/L1/Energy/Forward", "/Ac/Energy/Forward", "/StatusCode",
+        ]}
+        service.set_dbus_values()
+        self.assertEqual(service._dbusservice["/Ac/Energy/Forward"], 12.345)
+        self.assertEqual(service._dbusservice["/Ac/L1/Energy/Forward"], 12.345)
+        self.assertEqual(service._dbusservice["/Ac/Power"], 0)
+        self.assertEqual(service._dbusservice["/StatusCode"], STATUSCODE_ERROR)
 
 
 class ComputeStatusCodeTest(unittest.TestCase):

--- a/tests/test_dbus_service.py
+++ b/tests/test_dbus_service.py
@@ -818,11 +818,11 @@ class ComputeStatusCodeTest(unittest.TestCase):
         service.set_test_data({"inverters": [{"reachable": True, "producing": False}]})
         self.assertEqual(service._compute_status_code(), STATUSCODE_STANDBY)
 
-    def test_opendtu_unreachable_is_error(self):
-        from constants import STATUSCODE_ERROR
+    def test_opendtu_unreachable_is_standby(self):
+        from constants import STATUSCODE_STANDBY
         service = self._make("opendtu")
         service.set_test_data({"inverters": [{"reachable": False, "producing": False}]})
-        self.assertEqual(service._compute_status_code(), STATUSCODE_ERROR)
+        self.assertEqual(service._compute_status_code(), STATUSCODE_STANDBY)
 
 
 if __name__ == '__main__':

--- a/tests/test_dbus_service.py
+++ b/tests/test_dbus_service.py
@@ -98,6 +98,35 @@ def mocked_requests_get(url, params=None, **kwargs):  # pylint: disable=unused-a
         with open(json_file_path, 'r', encoding="UTF-8") as file:
             json_data = json.load(file)
         return MockResponse(json_data, 200)
+    elif url == 'http://localhost/api/limit/status':
+        json_file_path = os.path.join(os.path.dirname(__file__), '../docs/opendtu_limit_status.json')
+        with open(json_file_path, 'r', encoding="UTF-8") as file:
+            json_data = json.load(file)
+        return MockResponse(json_data, 200)
+    elif url.startswith('http://localhost/api/devinfo/status?inv='):
+        json_file_path = os.path.join(os.path.dirname(__file__), '../docs/opendtu_devinfo_status.json')
+        with open(json_file_path, 'r', encoding="UTF-8") as file:
+            json_data = json.load(file)
+        return MockResponse(json_data, 200)
+    return MockResponse(None, 404)
+
+
+def mocked_requests_post(url, data=None, **kwargs):  # pylint: disable=unused-argument
+    """Mock `requests.post` for OpenDTU /api/limit/config."""
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+        def raise_for_status(self):
+            if self.status_code != 200:
+                raise requests.exceptions.HTTPError(f"{self.status_code} Error")
+
+    if url == 'http://localhost/api/limit/config':
+        return MockResponse({"type": "success", "message": "Settings saved!"}, 200)
     return MockResponse(None, 404)
 
 
@@ -452,6 +481,274 @@ class ReconnectLogicTest(unittest.TestCase):
             self.assertEqual(service.retry_after_seconds, 123)
             self.assertEqual(service.min_retries_until_fail, 7)
             self.assertEqual(service.error_state_after_seconds, 456)
+
+
+class PowerLimitTest(unittest.TestCase):
+    """Tests for OpenDTU power-limit integration."""
+
+    def setUp(self):
+        DbusService._meter_data = None
+
+    def tearDown(self):
+        DbusService._meter_data = None
+
+    opendtu_config = {
+        "DEFAULT": {
+            "DTU": "opendtu",
+            "Username": "admin",
+            "Password": "secret",
+        },
+        "INVERTER0": {
+            "Phase": "L1",
+            "DeviceInstance": "34",
+            "AcPosition": "1",
+            "Host": "localhost",
+        },
+    }
+
+    def _make_service(self):
+        service = DbusService("com.victronenergy.pvinverter", 0)
+        # _dbusservice is a MagicMock by default; swap for a real dict for path I/O
+        service._dbusservice = {
+            "/Ac/MaxPower": None,
+            "/Ac/PowerLimit": None,
+            "/StatusCode": 7,
+        }
+        service.serial = "114182940773"
+        return service
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    def test_refresh_limit_status_publishes_max_power(
+            self, mock_get, mock_logging, mock_dbus, mock_config):
+        """_refresh_limit_status populates /Ac/MaxPower and /Ac/PowerLimit."""
+        DbusService._meter_data = None
+        service = self._make_service()
+        service._refresh_limit_status()
+        self.assertEqual(service._dbusservice["/Ac/MaxPower"], 2000)
+        # limit_relative=50 and max_power=2000 -> 1000W initial PowerLimit
+        self.assertEqual(service._dbusservice["/Ac/PowerLimit"], 1000.0)
+        self.assertEqual(service._dbusservice["/StatusCode"], 7)
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    def test_refresh_limit_status_maps_error_status(
+            self, mock_logging, mock_dbus, mock_config):
+        """Non-Ok limit_set_status maps to STATUSCODE_ERROR on /StatusCode."""
+        failing_payload = {
+            "114182940773": {"limit_relative": 50, "max_power": 2000, "limit_set_status": "Failure"}
+        }
+
+        def failing_get(url, **_kwargs):
+            if url.endswith("/livedata/status"):
+                return mocked_requests_get(url)
+            if url.endswith("/limit/status"):
+                class R:
+                    status_code = 200
+                    def json(self):
+                        return failing_payload
+                    def raise_for_status(self):
+                        pass
+                return R()
+            return mocked_requests_get(url)
+
+        DbusService._meter_data = None
+        with patch('dbus_service.requests.get', side_effect=failing_get):
+            service = self._make_service()
+            service._refresh_limit_status()
+        self.assertEqual(service._dbusservice["/StatusCode"], 10)
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    @patch('dbus_service.requests.post', side_effect=mocked_requests_post)
+    def test_apply_power_limit_posts_and_accepts(
+            self, mock_post, mock_get, mock_logging, mock_dbus, mock_config):
+        """Writing /Ac/PowerLimit POSTs the correct payload and the change is accepted."""
+        DbusService._meter_data = None
+        service = self._make_service()
+        # _refresh_limit_status needs a populated MaxPower for clamp logic; set directly
+        service._dbusservice["/Ac/MaxPower"] = 2000
+        accepted = service._handlechangedvalue("/Ac/PowerLimit", 300)
+        self.assertTrue(accepted)
+        self.assertEqual(mock_post.call_count, 1)
+        call_url = mock_post.call_args.kwargs.get("url") or mock_post.call_args.args[0]
+        self.assertEqual(call_url, "http://localhost/api/limit/config")
+        form = mock_post.call_args.kwargs["data"]
+        self.assertEqual(json.loads(form["data"]),
+                         {"serial": "114182940773", "limit_type": 0, "limit_value": 300})
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    @patch('dbus_service.requests.post', side_effect=requests.exceptions.ConnectionError("boom"))
+    def test_apply_power_limit_rejects_on_post_failure(
+            self, mock_post, mock_get, mock_logging, mock_dbus, mock_config):
+        """A failing POST causes _handlechangedvalue to return False (DBus write rejected)."""
+        DbusService._meter_data = None
+        service = self._make_service()
+        service._dbusservice["/Ac/MaxPower"] = 2000
+        accepted = service._handlechangedvalue("/Ac/PowerLimit", 500)
+        self.assertFalse(accepted)
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    def test_fetch_opendtu_devinfo_builds_url_and_returns_json(
+            self, mock_get, mock_logging, mock_dbus, mock_config):
+        """fetch_opendtu_devinfo calls /api/devinfo/status?inv=<serial> and returns parsed JSON."""
+        DbusService._meter_data = None
+        service = self._make_service()
+        data = service.fetch_opendtu_devinfo("114182940773")
+        self.assertEqual(data["hw_model_name"], "HMS-2000-4T")
+        self.assertEqual(data["fw_build_version"], 10027)
+        called_urls = [c.kwargs.get("url") or (c.args[0] if c.args else None)
+                       for c in mock_get.call_args_list]
+        self.assertIn("http://localhost/api/devinfo/status?inv=114182940773", called_urls)
+
+    def test_decode_version_int_and_string(self):
+        """Int versions split into 2-digit groups; strings pass through."""
+        self.assertEqual(DbusService._decode_version(10027), "1.0.27")
+        self.assertEqual(DbusService._decode_version(101), "0.1.1")
+        self.assertEqual(DbusService._decode_version("01.10"), "01.10")
+        self.assertIsNone(DbusService._decode_version(None))
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    def test_init_uses_devinfo_for_management_paths(
+            self, mock_get, mock_logging, mock_dbus, mock_config):
+        """At init, /ProductName, /FirmwareVersion, /HardwareVersion come from devinfo."""
+        DbusService._meter_data = None
+        service = DbusService("com.victronenergy.pvinverter", 0)
+        by_path = {c.args[0]: c.args[1] for c in service._dbusservice.add_path.call_args_list}
+        self.assertEqual(by_path["/ProductName"], "HMS-2000-4T")
+        self.assertEqual(by_path["/FirmwareVersion"], "1.0.27 (2023-06-05 10:24:00)")
+        self.assertEqual(by_path["/HardwareVersion"], "01.10")
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    def test_init_valid_data_false_sets_status_error(
+            self, mock_logging, mock_dbus, mock_config):
+        """valid_data=false in devinfo makes initial /StatusCode = ERROR."""
+        from constants import STATUSCODE_ERROR
+
+        def routed_get(url, **_kw):
+            if url.startswith("http://localhost/api/devinfo/status"):
+                class R:
+                    status_code = 200
+                    def json(self):
+                        return {"valid_data": False, "hw_model_name": "HMS-2000-4T",
+                                "hw_version": "01.10", "fw_build_version": 10027,
+                                "fw_build_datetime": "2023-06-05 10:24:00"}
+                    def raise_for_status(self):
+                        pass
+                return R()
+            return mocked_requests_get(url)
+
+        DbusService._meter_data = None
+        with patch('dbus_service.requests.get', side_effect=routed_get):
+            service = DbusService("com.victronenergy.pvinverter", 0)
+        by_path = {c.args[0]: c.args[1] for c in service._dbusservice.add_path.call_args_list}
+        self.assertEqual(by_path["/StatusCode"], STATUSCODE_ERROR)
+
+
+class PvInverterSchemaTest(unittest.TestCase):
+    """PVINVERTER_PATHS/VICTRON_PATHS separation and /Position + /PositionIsAdjustable."""
+
+    def test_pvinverter_paths_exclude_inverter_only(self):
+        from constants import PVINVERTER_PATHS, VICTRON_PATHS
+        self.assertNotIn("/Ac/Out/L1/I", PVINVERTER_PATHS)
+        self.assertNotIn("/Dc/0/Voltage", PVINVERTER_PATHS)
+        # VICTRON_PATHS is the superset used by the inverter service
+        self.assertIn("/Ac/Out/L1/I", VICTRON_PATHS)
+        self.assertIn("/Dc/0/Voltage", VICTRON_PATHS)
+        # Shared pvinverter paths appear in both
+        self.assertIn("/Ac/MaxPower", PVINVERTER_PATHS)
+        self.assertIn("/Ac/PowerLimit", PVINVERTER_PATHS)
+
+    opendtu_config = {
+        "DEFAULT": {"DTU": "opendtu"},
+        "INVERTER0": {
+            "Phase": "L1", "DeviceInstance": "34", "AcPosition": "1", "Host": "localhost",
+        },
+    }
+
+    def setUp(self):
+        DbusService._meter_data = None
+
+    def tearDown(self):
+        DbusService._meter_data = None
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    def test_pvinverter_registers_position_paths(
+            self, mock_get, mock_logging, mock_dbus, mock_config):
+        """Pvinverter service registers /Position and /PositionIsAdjustable=1."""
+        service = DbusService("com.victronenergy.pvinverter", 0)
+        registered_paths = [call.args[0] for call in service._dbusservice.add_path.call_args_list]
+        self.assertIn("/Position", registered_paths)
+        self.assertIn("/PositionIsAdjustable", registered_paths)
+        # /PositionIsAdjustable is registered with initial=1
+        position_adj_call = next(c for c in service._dbusservice.add_path.call_args_list
+                                 if c.args[0] == "/PositionIsAdjustable")
+        self.assertEqual(position_adj_call.args[1], 1)
+
+    @patch('dbus_service.DbusService._get_config', return_value=opendtu_config)
+    @patch('dbus_service.dbus')
+    @patch('dbus_service.logging')
+    @patch('dbus_service.requests.get', side_effect=mocked_requests_get)
+    def test_init_status_code_is_startup(
+            self, mock_get, mock_logging, mock_dbus, mock_config):
+        """Initial /StatusCode is STARTUP(0), not RUNNING(7)."""
+        from constants import STATUSCODE_STARTUP
+        service = DbusService("com.victronenergy.pvinverter", 0)
+        status_calls = [c for c in service._dbusservice.add_path.call_args_list
+                        if c.args[0] == "/StatusCode"]
+        self.assertEqual(status_calls[0].args[1], STATUSCODE_STARTUP)
+
+
+class ComputeStatusCodeTest(unittest.TestCase):
+    """Tests for _compute_status_code mapping reachable/producing onto StatusCode."""
+
+    def setUp(self):
+        DbusService._meter_data = None
+
+    def tearDown(self):
+        DbusService._meter_data = None
+
+    def _make(self, dtuvariant):
+        service = DbusService(servicename="testing", actual_inverter=0)
+        service.dtuvariant = dtuvariant
+        return service
+
+    def test_opendtu_reachable_and_producing_is_running(self):
+        from constants import STATUSCODE_RUNNING
+        service = self._make("opendtu")
+        service.set_test_data({"inverters": [{"reachable": True, "producing": True}]})
+        self.assertEqual(service._compute_status_code(), STATUSCODE_RUNNING)
+
+    def test_opendtu_reachable_not_producing_is_standby(self):
+        from constants import STATUSCODE_STANDBY
+        service = self._make("opendtu")
+        service.set_test_data({"inverters": [{"reachable": True, "producing": False}]})
+        self.assertEqual(service._compute_status_code(), STATUSCODE_STANDBY)
+
+    def test_opendtu_unreachable_is_error(self):
+        from constants import STATUSCODE_ERROR
+        service = self._make("opendtu")
+        service.set_test_data({"inverters": [{"reachable": False, "producing": False}]})
+        self.assertEqual(service._compute_status_code(), STATUSCODE_ERROR)
 
 
 if __name__ == '__main__':

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,5 @@
 # Set the repository name and username
-REPO="henne49/dbus-opendtu"
+REPO="thallth/dbus-opendtu"
 STARTUP_FILE="/data/rc.local"
 #!/bin/bash
 
@@ -67,9 +67,9 @@ else
   INSTALLED_VERSION="none"
 fi
 
-# delete old logs if they exist  
-if [ -f $SCRIPT_DIR/current.log ]; then  
-    rm $SCRIPT_DIR/current.log*  
+# delete old logs if they exist
+if [ -f $SCRIPT_DIR/current.log ]; then
+    rm $SCRIPT_DIR/current.log*
 fi
 
 # Check if the current folder has enough space for 5MB
@@ -94,7 +94,7 @@ if [ "$VERSION" = "latest" ]; then
   # Fetch the latest release information from the GitHub API
   # and extract the latest tag name using awk
   # Assuming GitHub API returns the latest release tag in the format "vX.X.X"
-  LATEST_TAG=$(curl -s https://api.github.com/repos/$REPO/releases/latest | 
+  LATEST_TAG=$(curl -s https://api.github.com/repos/$REPO/releases/latest |
                awk -F'"' '/tag_name/{print $4}')
   TAG=$LATEST_TAG
 else
@@ -103,8 +103,8 @@ else
     # Fetch the latest pre-release information from the GitHub API
     # and extract the latest pre-release tag name using awk
     # Assuming GitHub API returns pre-release tags in the format "vX.X.X-rc.X" or "vX.X.X-beta.X"
-    PRE_RELEASE_TAG=$(curl -s https://api.github.com/repos/$REPO/releases | 
-                      awk -F'"' '/tag_name/{print $4}' | 
+    PRE_RELEASE_TAG=$(curl -s https://api.github.com/repos/$REPO/releases |
+                      awk -F'"' '/tag_name/{print $4}' |
                       grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+$')
     TAG=$PRE_RELEASE_TAG
   else
@@ -171,4 +171,3 @@ $SCRIPT_DIR/install.sh
 
 #restart the service
 $SCRIPT_DIR/restart.sh
-

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-Version: 2.1.2
+Version: 3.0.0


### PR DESCRIPTION
Implemented the power-limit control feature for OpenDTU.

Tested with Victron Ekrano and OpenDTU with Hoymiles HMS 2000-4T, running for 4 months now without any problems.
Power limit is shown and controlled within the Victron ESS, similar to Fronius inverters.

Power-limit takes place when battery is getting to 100% SoC and exceeding PV power should not be exported to the grid at this point in time (or is off-grid). This is controlled automatically from the Victron ESS.
It does not use the "fallback" frequency increase, but uses directly the OpenDTU power-limit via software.

Most important changes:
- Add OpenDTU power-limit control, devinfo metadata, and pvinverter schema cleanup
- Fix offline/night data publishing and harden dbus text callbacks